### PR TITLE
feat: web theme & prompt edit fixed

### DIFF
--- a/web/src/app/application/structure/components/character-config/index.tsx
+++ b/web/src/app/application/structure/components/character-config/index.tsx
@@ -4,6 +4,7 @@ import { AppContext } from '@/contexts';
 import { CaretLeftOutlined } from '@ant-design/icons';
 import { useDebounceFn, useRequest } from 'ahooks';
 import { Collapse } from 'antd';
+import { debounce } from 'lodash';
 import { useContext, useMemo } from 'react';
 
 function CharacterConfig() {
@@ -20,7 +21,7 @@ function CharacterConfig() {
     },
   });
 
-  const { run: handleSysPromptChange } = useDebounceFn(
+  const { run: updateSysPrompt } = useDebounceFn(
     template =>
       fetchUpdateApp({
         ...appInfo,
@@ -31,7 +32,7 @@ function CharacterConfig() {
     },
   );
 
-  const { run: handleUserPromptChange } = useDebounceFn(
+  const { run: updateUserPrompt } = useDebounceFn(
     template =>
       fetchUpdateApp({
         ...appInfo,
@@ -41,6 +42,15 @@ function CharacterConfig() {
       wait: 500,
     },
   );
+
+  const handleSysPromptChange = debounce((temp) => {
+    updateSysPrompt(temp);
+  }, 800);
+
+  const handleUserPromptChange = debounce((temp) => {
+    updateUserPrompt(temp);
+  }, 800);
+
   const systemPrompt = useMemo(() => {
     return system_prompt_template || '';
   }, [system_prompt_template]);

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -130,7 +130,7 @@ export default function RootLayout({
       <body suppressHydrationWarning={true}>
         <Suspense fallback={
           <App className="w-screen h-screen flex items-center justify-center">
-            <Spin size="large" />
+            <Spin />
           </App>
           }>
           <ChatContextProvider>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,7 +7,7 @@ import {
   STORAGE_USERINFO_KEY,
   STORAGE_USERINFO_VALID_TIME_KEY,
 } from "@/utils/constants/index";
-import { App, ConfigProvider, MappingAlgorithm, theme } from "antd";
+import { App, ConfigProvider, MappingAlgorithm, Spin, theme } from "antd";
 import enUS from "antd/locale/en_US";
 import zhCN from "antd/locale/zh_CN";
 import Head from "next/head";
@@ -110,7 +110,9 @@ function LayoutWrapper({ children }: { children: React.ReactNode }) {
           colorPrimary: "#0C75FC",
           borderRadius: 4,
         },
-        algorithm: mode === "dark" ? antdDarkTheme : undefined,
+        // algorithm: mode === "dark" ? antdDarkTheme : undefined,
+        // 暂不支持 dark 
+        algorithm: undefined,
       }}
     >
       <App>{renderContent()}</App>
@@ -124,9 +126,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning data-theme="light" className="light">
       <body suppressHydrationWarning={true}>
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={
+          <App className="w-screen h-screen flex items-center justify-center">
+            <Spin size="large" />
+          </App>
+          }>
           <ChatContextProvider>
             <CssWrapper>
               <LayoutWrapper>{children}</LayoutWrapper>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,7 +16,6 @@ export default function Home() {
     }
   },[pathname, router])
 
-
   return (
      <div className='h-screen flex flex-col items-center justify-center'>
       <div className='flex-1 flex flex-col justify-center items-center w-4/5'>

--- a/web/src/contexts/chat-context.tsx
+++ b/web/src/contexts/chat-context.tsx
@@ -83,7 +83,7 @@ const ChatContextProvider = ({ children }: { children: React.ReactElement }) => 
   const scene = searchParams?.get('scene') ?? '';
   const db_param = searchParams?.get('db_param') ?? '';
   const [isContract, setIsContract] = useState(false);
-  const [model, setModel] = useState<string>('');
+  const [model, setModel] = useState<string>('light');
   const [isMenuExpand, setIsMenuExpand] = useState<boolean>(scene !== 'chat_dashboard');
   const [dbParam, setDbParam] = useState<string>(db_param);
   const [agent, setAgent] = useState<string>('');
@@ -115,7 +115,7 @@ const ChatContextProvider = ({ children }: { children: React.ReactElement }) => 
   });
 
   useEffect(() => {
-    setMode(getDefaultTheme());
+    // setMode(getDefaultTheme());
     try {
       const dialogInfo = JSON.parse(localStorage.getItem('cur_dialog_info') || '');
       setCurrentDialogInfo(dialogInfo);


### PR DESCRIPTION
# Description

web theme fixed, when the system is set to dark, the page theme remains unchanged.
prompt edit fixed

# How Has This Been Tested?

# Snapshots:
<img width="1156" height="1422" alt="image" src="https://github.com/user-attachments/assets/2c696720-5e6a-4f66-91a3-f84cdeb88408" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
