### PR TITLE
feat(channel): add cron job message delivery via DingTalk/Feishu channels

### DIFF
--- a/packages/derisk-core/src/derisk/channel/__init__.py
+++ b/packages/derisk-core/src/derisk/channel/__init__.py
@@ -6,6 +6,7 @@ including:
 - Channel configuration
 - Channel message format
 - Channel handler interface
+- Message router for agent integration
 
 Example:
     ```python
@@ -31,11 +32,15 @@ Example:
 from .base import (
     ChannelCapabilities,
     ChannelConfig,
+    ChannelConnectionState,
     ChannelHandler,
     ChannelMessage,
     ChannelSender,
     ChannelType,
+    SendMessageResult,
 )
+from .registry import ChannelHandlerRegistry
+from .router import ChannelMessageRouter
 from .schemas import DingTalkConfig, FeishuConfig
 
 __all__ = [
@@ -45,8 +50,14 @@ __all__ = [
     "ChannelSender",
     "ChannelMessage",
     "ChannelCapabilities",
+    "ChannelConnectionState",
+    "SendMessageResult",
     # Interfaces
     "ChannelHandler",
+    # Registry
+    "ChannelHandlerRegistry",
+    # Router
+    "ChannelMessageRouter",
     # Platform configs
     "DingTalkConfig",
     "FeishuConfig",

--- a/packages/derisk-core/src/derisk/channel/base.py
+++ b/packages/derisk-core/src/derisk/channel/base.py
@@ -12,6 +12,39 @@ from typing import Any, Dict, List, Optional
 from derisk._private.pydantic import BaseModel, ConfigDict, Field
 
 
+class ChannelConnectionState(str, Enum):
+    """Channel connection state enumeration."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    ERROR = "error"
+    RECONNECTING = "reconnecting"
+
+
+class SendMessageResult(BaseModel):
+    """Result of sending a message through a channel."""
+
+    model_config = ConfigDict(title="SendMessageResult")
+
+    success: bool = Field(
+        ...,
+        description="Whether the message was sent successfully",
+    )
+    message_id: Optional[str] = Field(
+        default=None,
+        description="Message ID returned by the channel platform",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message if sending failed",
+    )
+    timestamp: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when the message was sent",
+    )
+
+
 class ChannelType(str, Enum):
     """Channel type enumeration."""
 
@@ -83,7 +116,7 @@ class ChannelCapabilities(BaseModel):
 class ChannelConfig(BaseModel):
     """Base channel configuration."""
 
-    model_config = ConfigDict(title="ChannelConfig")
+    model_config = ConfigDict(title="ChannelConfig", extra="allow")
 
     enabled: bool = Field(
         default=True,
@@ -96,6 +129,10 @@ class ChannelConfig(BaseModel):
     description: Optional[str] = Field(
         default=None,
         description="Channel description",
+    )
+    platform_config: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Platform-specific configuration (FeishuConfig, DingTalkConfig, etc.)",
     )
 
 
@@ -160,6 +197,88 @@ class ChannelHandler(ABC):
     Channel handlers are implemented in derisk-ext for specific platforms.
     They handle message processing, signature validation, and capability reporting.
     """
+
+    def __init__(self, channel_id: str, config: "ChannelConfig"):
+        """Initialize the channel handler.
+
+        Args:
+            channel_id: The unique identifier for this channel.
+            config: The channel configuration.
+        """
+        self._channel_id = channel_id
+        self._config = config
+        self._connection_state: ChannelConnectionState = (
+            ChannelConnectionState.DISCONNECTED
+        )
+
+    @classmethod
+    def get_default_capabilities(cls) -> ChannelCapabilities:
+        """Get default capabilities for this channel type.
+
+        This class method can be called without instantiating the handler.
+        Subclasses should override this to return their specific capabilities.
+
+        Returns:
+            ChannelCapabilities instance with default values.
+        """
+        return ChannelCapabilities()
+
+    @property
+    def channel_id(self) -> str:
+        """Get the channel ID."""
+        return self._channel_id
+
+    @property
+    def connection_state(self) -> ChannelConnectionState:
+        """Get the current connection state."""
+        return self._connection_state
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the channel handler.
+
+        This should establish the connection to the platform (WebSocket, Stream, etc.)
+        and start listening for incoming messages.
+        """
+        pass
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the channel handler.
+
+        This should close all connections and stop listening for messages.
+        """
+        pass
+
+    @abstractmethod
+    async def send_message(
+        self,
+        receiver_id: str,
+        content: str,
+        content_type: str = "text",
+        **kwargs,
+    ) -> SendMessageResult:
+        """Send a message to a receiver through this channel.
+
+        Args:
+            receiver_id: The ID of the receiver (user or group).
+            content: The message content.
+            content_type: The content type (text, markdown, etc.).
+            **kwargs: Additional parameters (reply_to, mentions, etc.).
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        pass
+
+    @abstractmethod
+    def get_connection_url(self) -> Optional[str]:
+        """Get the webhook URL for setting up the channel integration.
+
+        Returns:
+            The webhook URL if applicable, None if using WebSocket/Stream mode.
+        """
+        pass
 
     @abstractmethod
     async def process_message(

--- a/packages/derisk-core/src/derisk/channel/registry.py
+++ b/packages/derisk-core/src/derisk/channel/registry.py
@@ -1,0 +1,202 @@
+"""Channel handler registry for managing channel handlers.
+
+This module provides a registry for channel handlers that can be used to
+manage and retrieve handlers by channel type and ID.
+"""
+
+import logging
+from typing import Callable, Dict, Optional, Type
+
+from derisk.channel.base import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelHandler,
+    ChannelType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelHandlerRegistry:
+    """Registry for channel handlers.
+
+    This registry manages channel handlers by their type and ID.
+    It supports:
+    - Registering handler classes by channel type
+    - Creating handler instances for specific channels
+    - Retrieving active handlers by channel ID
+    """
+
+    _instance: Optional["ChannelHandlerRegistry"] = None
+
+    def __new__(cls) -> "ChannelHandlerRegistry":
+        """Create or return the singleton instance."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        """Initialize the registry."""
+        if self._initialized:
+            return
+        self._initialized = True
+        self._handler_classes: Dict[ChannelType, Type[ChannelHandler]] = {}
+        self._active_handlers: Dict[str, ChannelHandler] = {}
+        self._factories: Dict[
+            ChannelType, Callable[[str, ChannelConfig], ChannelHandler]
+        ] = {}
+        logger.info("ChannelHandlerRegistry initialized")
+
+    @classmethod
+    def get_instance(cls) -> "ChannelHandlerRegistry":
+        """Get the singleton registry instance."""
+        return cls()
+
+    def register_handler_class(
+        self,
+        channel_type: ChannelType,
+        handler_class: Type[ChannelHandler],
+    ) -> None:
+        """Register a handler class for a channel type.
+
+        Args:
+            channel_type: The channel type.
+            handler_class: The handler class to register.
+        """
+        self._handler_classes[channel_type] = handler_class
+        logger.info(f"Registered handler class for channel type: {channel_type}")
+
+    def register_factory(
+        self,
+        channel_type: ChannelType,
+        factory: Callable[[str, ChannelConfig], ChannelHandler],
+    ) -> None:
+        """Register a factory function for creating handlers.
+
+        Args:
+            channel_type: The channel type.
+            factory: Factory function that creates handler instances.
+        """
+        self._factories[channel_type] = factory
+        logger.info(f"Registered factory for channel type: {channel_type}")
+
+    def create_handler(
+        self,
+        channel_id: str,
+        channel_type: ChannelType,
+        config: ChannelConfig,
+    ) -> Optional[ChannelHandler]:
+        """Create a handler instance for a channel.
+
+        Args:
+            channel_id: The unique channel identifier.
+            channel_type: The channel type.
+            config: The channel configuration.
+
+        Returns:
+            The created handler instance, or None if creation failed.
+        """
+        if channel_id in self._active_handlers:
+            logger.warning(f"Handler already exists for channel: {channel_id}")
+            return self._active_handlers[channel_id]
+
+        handler: Optional[ChannelHandler] = None
+
+        if channel_type in self._factories:
+            try:
+                handler = self._factories[channel_type](channel_id, config)
+            except Exception as e:
+                logger.error(f"Failed to create handler using factory: {e}")
+                return None
+        elif channel_type in self._handler_classes:
+            handler_class = self._handler_classes[channel_type]
+            try:
+                handler = handler_class(channel_id=channel_id, config=config)
+            except Exception as e:
+                logger.error(f"Failed to create handler instance: {e}")
+                return None
+        else:
+            logger.error(f"No handler registered for channel type: {channel_type}")
+            return None
+
+        if handler:
+            self._active_handlers[channel_id] = handler
+            logger.info(f"Created handler for channel: {channel_id}")
+
+        return handler
+
+    def get_handler(self, channel_id: str) -> Optional[ChannelHandler]:
+        """Get an active handler by channel ID.
+
+        Args:
+            channel_id: The channel identifier.
+
+        Returns:
+            The handler instance, or None if not found.
+        """
+        return self._active_handlers.get(channel_id)
+
+    def remove_handler(self, channel_id: str) -> bool:
+        """Remove a handler from the registry.
+
+        Args:
+            channel_id: The channel identifier.
+
+        Returns:
+            True if the handler was removed, False if not found.
+        """
+        if channel_id in self._active_handlers:
+            del self._active_handlers[channel_id]
+            logger.info(f"Removed handler for channel: {channel_id}")
+            return True
+        return False
+
+    async def stop_handler(self, channel_id: str) -> bool:
+        """Stop and remove a handler.
+
+        Args:
+            channel_id: The channel identifier.
+
+        Returns:
+            True if the handler was stopped and removed, False if not found.
+        """
+        handler = self.get_handler(channel_id)
+        if handler:
+            try:
+                await handler.stop()
+            except Exception as e:
+                logger.error(f"Error stopping handler: {e}")
+            self.remove_handler(channel_id)
+            return True
+        return False
+
+    def get_capabilities(
+        self, channel_type: ChannelType
+    ) -> Optional[ChannelCapabilities]:
+        """Get capabilities for a channel type.
+
+        Args:
+            channel_type: The channel type.
+
+        Returns:
+            The capabilities, or None if no handler is registered.
+        """
+        if channel_type in self._handler_classes:
+            handler_class = self._handler_classes[channel_type]
+            # Use the class method to get default capabilities without instantiation
+            try:
+                return handler_class.get_default_capabilities()
+            except Exception as e:
+                logger.warning(f"Failed to get default capabilities: {e}")
+        return None
+
+    def get_registered_types(self) -> list:
+        """Get list of registered channel types.
+
+        Returns:
+            List of registered channel types.
+        """
+        return list(
+            set(list(self._handler_classes.keys()) + list(self._factories.keys()))
+        )

--- a/packages/derisk-core/src/derisk/channel/router.py
+++ b/packages/derisk-core/src/derisk/channel/router.py
@@ -1,0 +1,278 @@
+"""Channel message router for routing messages to agents.
+
+This module provides a message router that routes incoming channel messages
+to appropriate agents and handles agent responses.
+"""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, List, Optional
+
+from derisk.channel.base import (
+    ChannelHandler,
+    ChannelMessage,
+    SendMessageResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MessageHandler(ABC):
+    """Abstract base class for message handlers.
+
+    Message handlers are responsible for processing channel messages
+    and generating responses.
+    """
+
+    @abstractmethod
+    async def handle_message(
+        self,
+        message: ChannelMessage,
+        channel_handler: ChannelHandler,
+        channel_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Handle an incoming channel message.
+
+        Args:
+            message: The incoming message.
+            channel_handler: The channel handler for sending responses.
+            channel_id: The channel configuration ID.
+
+        Returns:
+            Optional response content to send back.
+        """
+        pass
+
+
+class ChannelMessageRouter:
+    """Router for channel messages.
+
+    This router routes incoming channel messages to appropriate handlers
+    and manages the message processing pipeline.
+    """
+
+    def __init__(self):
+        """Initialize the router."""
+        self._handlers: Dict[str, MessageHandler] = {}
+        self._default_handler: Optional[MessageHandler] = None
+        self._middleware: List[Callable] = []
+        self._running = False
+
+    def register_handler(
+        self,
+        channel_id: str,
+        handler: MessageHandler,
+    ) -> None:
+        """Register a message handler for a specific channel.
+
+        Args:
+            channel_id: The channel identifier.
+            handler: The message handler.
+        """
+        self._handlers[channel_id] = handler
+        logger.info(f"Registered message handler for channel: {channel_id}")
+
+    def unregister_handler(self, channel_id: str) -> None:
+        """Unregister a message handler.
+
+        Args:
+            channel_id: The channel identifier.
+        """
+        if channel_id in self._handlers:
+            del self._handlers[channel_id]
+            logger.info(f"Unregistered message handler for channel: {channel_id}")
+
+    def set_default_handler(self, handler: MessageHandler) -> None:
+        """Set the default message handler.
+·
+        The default handler is used when no specific handler is registered
+        for a channel.
+
+        Args:
+            handler: The default message handler.
+        """
+        self._default_handler = handler
+        logger.info("Set default message handler")
+
+    def add_middleware(self, middleware: Callable) -> None:
+        """Add middleware to the processing pipeline.
+
+        Middleware functions are called before the message handler.
+        They can modify the message or perform additional processing.
+
+        Args:
+            middleware: Middleware function that takes a ChannelMessage
+                       and returns a (possibly modified) ChannelMessage.
+        """
+        self._middleware.append(middleware)
+        logger.info("Added middleware to message router")
+
+    async def route_message(
+        self,
+        channel_id: str,
+        message: ChannelMessage,
+        channel_handler: ChannelHandler,
+    ) -> Optional[SendMessageResult]:
+        """Route a message to the appropriate handler.
+
+        Args:
+            channel_id: The channel identifier.
+            message: The incoming message.
+            channel_handler: The channel handler for sending responses.
+
+        Returns:
+            SendMessageResult if a response was sent, None otherwise.
+        """
+        processed_message = message
+
+        for middleware in self._middleware:
+            try:
+                result = await middleware(processed_message)
+                if result is not None:
+                    processed_message = result
+            except Exception as e:
+                logger.error(f"Middleware error: {e}")
+
+        handler = self._handlers.get(channel_id, self._default_handler)
+
+        if handler is None:
+            logger.warning(f"No handler found for channel: {channel_id}")
+            return None
+
+        try:
+            response = await handler.handle_message(
+                processed_message, channel_handler, channel_id=channel_id
+            )
+
+            if response:
+                receiver_id = (
+                    message.conversation_id
+                    if message.is_group
+                    else message.sender.user_id
+                )
+
+                if receiver_id:
+                    reply_to = message.message_id
+                    return await channel_handler.send_message(
+                        receiver_id=receiver_id,
+                        content=response,
+                        reply_to=reply_to,
+                    )
+
+        except Exception as e:
+            logger.error(f"Error handling message: {e}")
+            return None
+
+        return None
+
+    async def start(self) -> None:
+        """Start the router."""
+        self._running = True
+        logger.info("Channel message router started")
+
+    async def stop(self) -> None:
+        """Stop the router."""
+        self._running = False
+        logger.info("Channel message router stopped")
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the router is running."""
+        return self._running
+
+
+class AgentMessageHandler(MessageHandler):
+    """Message handler that integrates with the agent system.
+
+    This handler creates a conversation context from channel messages
+    and delegates to the agent system for processing.
+    """
+
+    def __init__(
+        self,
+        agent_app_code: str = "main-orchestrator",
+        get_agent_response: Optional[Callable] = None,
+    ):
+        """Initialize the agent message handler.
+
+        Args:
+            agent_app_code: The agent app code to use.
+            get_agent_response: Optional function to get agent responses.
+                               If None, a default implementation will be used.
+        """
+        self._agent_app_code = agent_app_code
+        self._get_agent_response = get_agent_response
+        self._conversation_histories: Dict[str, List] = {}
+
+    async def handle_message(
+        self,
+        message: ChannelMessage,
+        channel_handler: ChannelHandler,
+        channel_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Handle an incoming message by routing to an agent.
+
+        Args:
+            message: The incoming message.
+            channel_handler: The channel handler for sending responses.
+            channel_id: The channel configuration ID.
+
+        Returns:
+            The agent's response content.
+        """
+        conversation_key = message.conversation_id or message.sender.user_id
+
+        if conversation_key not in self._conversation_histories:
+            self._conversation_histories[conversation_key] = []
+
+        history = self._conversation_histories[conversation_key]
+
+        history.append(
+            {
+                "role": "user",
+                "content": message.content,
+            }
+        )
+
+        if len(history) > 20:
+            history = history[-20:]
+            self._conversation_histories[conversation_key] = history
+
+        # Build channel context for passing to agent
+        channel_context = {
+            "channel_id": channel_id,
+            "channel_type": message.channel_type.value if message.channel_type else None,
+            "receiver_id": message.conversation_id
+            if message.is_group
+            else message.sender.user_id,
+            "is_group": message.is_group,
+        }
+
+        if self._get_agent_response:
+            try:
+                response = await self._get_agent_response(
+                    message=message,
+                    history=history,
+                    agent_app_code=self._agent_app_code,
+                    channel_context=channel_context,
+                )
+                return response
+            except Exception as e:
+                logger.error(f"Error getting agent response: {e}")
+                return f"Error processing message: {str(e)}"
+        else:
+            return f"Received your message: {message.content}"
+
+    def clear_conversation(self, conversation_key: str) -> None:
+        """Clear conversation history.
+
+        Args:
+            conversation_key: The conversation key.
+        """
+        if conversation_key in self._conversation_histories:
+            del self._conversation_histories[conversation_key]
+
+    def clear_all_conversations(self) -> None:
+        """Clear all conversation histories."""
+        self._conversation_histories.clear()

--- a/packages/derisk-ext/src/derisk_ext/channels/__init__.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/__init__.py
@@ -1,0 +1,13 @@
+"""Channel implementations for various platforms.
+
+This package provides concrete implementations of channel handlers
+for platforms like Feishu and DingTalk.
+"""
+
+from derisk_ext.channels.feishu import FeishuChannelHandler
+from derisk_ext.channels.dingtalk import DingTalkChannelHandler
+
+__all__ = [
+    "FeishuChannelHandler",
+    "DingTalkChannelHandler",
+]

--- a/packages/derisk-ext/src/derisk_ext/channels/dingtalk/__init__.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/dingtalk/__init__.py
@@ -1,0 +1,15 @@
+"""DingTalk channel implementation.
+
+This module provides a complete implementation for DingTalk integration
+using the official dingtalk-stream SDK with Stream mode for receiving messages.
+"""
+
+from derisk_ext.channels.dingtalk.client import DingTalkClient
+from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+from derisk_ext.channels.dingtalk.sender import DingTalkSender
+
+__all__ = [
+    "DingTalkClient",
+    "DingTalkChannelHandler",
+    "DingTalkSender",
+]

--- a/packages/derisk-ext/src/derisk_ext/channels/dingtalk/client.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/dingtalk/client.py
@@ -1,0 +1,502 @@
+"""DingTalk API client using dingtalk-stream SDK.
+
+This module provides a client for interacting with DingTalk APIs
+using the official dingtalk-stream Python SDK with Stream mode.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+import httpx
+
+from derisk.channel.base import SendMessageResult
+from derisk.channel.schemas import DingTalkConfig
+
+if TYPE_CHECKING:
+    import dingtalk_stream
+
+logger = logging.getLogger(__name__)
+
+
+class DingTalkChatbotHandler:
+    """Handler for DingTalk robot chat messages.
+
+    This handler uses ChatbotHandler to process robot chat messages
+    (private messages and group @mentions).
+    """
+
+    def __init__(self, message_callback: Callable[[Dict[str, Any]], None]):
+        """Initialize the handler.
+
+        Args:
+            message_callback: Callback function to handle parsed messages.
+        """
+        self._message_callback = message_callback
+        self._handler: Optional["dingtalk_stream.ChatbotHandler"] = None
+
+    def create_handler(self) -> "dingtalk_stream.ChatbotHandler":
+        """Create and return the actual ChatbotHandler instance.
+
+        Returns:
+            A ChatbotHandler instance configured with the message callback.
+        """
+        import dingtalk_stream
+
+        class _ChatbotHandler(dingtalk_stream.ChatbotHandler):
+            """Inner ChatbotHandler implementation."""
+
+            def __init__(
+                self, callback: Callable[[Dict[str, Any]], None]
+            ):
+                super().__init__()
+                self._callback = callback
+
+            async def process(
+                self, callback_message: dingtalk_stream.CallbackMessage
+            ) -> tuple:
+                """Process incoming chatbot message.
+
+                Args:
+                    callback_message: The CallbackMessage containing the message data.
+
+                Returns:
+                    Tuple of (AckMessage.STATUS_OK, 'OK') on success.
+                """
+                try:
+                    # Parse as ChatbotMessage
+                    chatbot_msg = dingtalk_stream.ChatbotMessage.from_dict(
+                        callback_message.data
+                    )
+
+                    # Convert to standard format
+                    event_dict = self._convert_to_event_dict(
+                        chatbot_msg, callback_message
+                    )
+
+                    if self._callback:
+                        await asyncio.to_thread(self._callback, event_dict)
+
+                except Exception as e:
+                    logger.error(f"Error processing chatbot message: {e}")
+
+                return dingtalk_stream.AckMessage.STATUS_OK, "OK"
+
+            def _convert_to_event_dict(
+                self,
+                msg: dingtalk_stream.ChatbotMessage,
+                callback: dingtalk_stream.CallbackMessage,
+            ) -> Dict[str, Any]:
+                """Convert ChatbotMessage to standard event dictionary.
+
+                Args:
+                    msg: The parsed ChatbotMessage.
+                    callback: The original CallbackMessage.
+
+                Returns:
+                    A dictionary with standardized message fields.
+                """
+                return {
+                    "event_type": "chatbot_message",
+                    "message_id": msg.message_id,
+                    "conversation_id": msg.conversation_id,
+                    "conversation_type": (
+                        "group" if msg.conversation_type == "2" else "private"
+                    ),
+                    "conversation_title": msg.conversation_title,
+                    "sender_id": msg.sender_id,
+                    "sender_nick": msg.sender_nick,
+                    "sender_staff_id": msg.sender_staff_id,
+                    "sender_corp_id": msg.sender_corp_id,
+                    "robot_code": msg.robot_code,
+                    "message_type": msg.message_type,
+                    "text": msg.text.content if msg.text else "",
+                    "at_users": (
+                        [u.to_dict() for u in msg.at_users]
+                        if msg.at_users
+                        else []
+                    ),
+                    "session_webhook": msg.session_webhook,
+                    "create_at": msg.create_at,
+                    "is_in_at_list": msg.is_in_at_list,
+                    "raw_message": msg,
+                    "raw_callback": callback,
+                }
+
+        self._handler = _ChatbotHandler(self._message_callback)
+        return self._handler
+
+DINGTALK_API_BASE = "https://oapi.dingtalk.com"
+DINGTALK_TOP_API_BASE = "https://api.dingtalk.com"
+
+
+class DingTalkClient:
+    """DingTalk API client.
+
+    This client handles:
+    - Authentication and token management
+    - Stream mode connection for receiving events
+    - Message sending via REST API
+    - User and conversation information retrieval
+    """
+
+    def __init__(
+        self,
+        config: DingTalkConfig,
+        message_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ):
+        """Initialize the DingTalk client.
+
+        Args:
+            config: DingTalk configuration.
+            message_callback: Optional callback for received messages.
+        """
+        self._config = config
+        self._message_callback = message_callback
+        self._access_token: Optional[str] = None
+        self._token_expires_at: float = 0
+        self._running = False
+        self._stream_client: Optional[Any] = None
+        self._stream_thread: Optional[threading.Thread] = None
+
+        self._http_client = httpx.AsyncClient(timeout=30.0)
+
+        logger.info(f"DingTalkClient initialized for app_id: {config.app_id}")
+
+    async def _get_access_token(self) -> Optional[str]:
+        """Get or refresh the access token.
+
+        Returns:
+            The access token or None if failed.
+        """
+        if self._access_token and time.time() < self._token_expires_at:
+            return self._access_token
+
+        try:
+            url = f"{DINGTALK_API_BASE}/gettoken"
+            params = {
+                "appkey": self._config.app_id,
+                "appsecret": self._config.app_secret,
+            }
+
+            response = await self._http_client.get(url, params=params)
+            result = response.json()
+
+            if result.get("errcode") == 0:
+                self._access_token = result.get("access_token")
+                expires_in = result.get("expires_in", 7200)
+                self._token_expires_at = time.time() + expires_in - 300
+                logger.info("Successfully obtained DingTalk access token")
+                return self._access_token
+            else:
+                logger.error(f"Failed to get access token: {result}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Error getting access token: {e}")
+            return None
+
+    async def start(self) -> None:
+        """Start the Stream mode connection for receiving events."""
+        if self._running:
+            logger.warning("DingTalk client is already running")
+            return
+
+        self._running = True
+
+        try:
+            await self._start_stream_mode()
+            logger.info("DingTalk client started")
+        except Exception as e:
+            logger.error(f"Failed to start DingTalk client: {e}")
+            self._running = False
+
+    async def _start_stream_mode(self) -> None:
+        """Start Stream mode for receiving robot messages using ChatbotHandler."""
+        try:
+            import dingtalk_stream
+
+            # Create credential and client
+            credential = dingtalk_stream.Credential(
+                client_id=self._config.app_id,
+                client_secret=self._config.app_secret,
+            )
+            self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
+
+            # Register chatbot handler for robot messages
+            # ChatbotMessage.TOPIC = '/v1.0/im/bot/messages/get'
+            chatbot_handler = DingTalkChatbotHandler(self._message_callback)
+            self._stream_client.register_callback_handler(
+                dingtalk_stream.ChatbotMessage.TOPIC,
+                chatbot_handler.create_handler(),
+            )
+
+            def run_stream():
+                try:
+                    self._stream_client.start_forever()
+                except Exception as e:
+                    logger.error(f"Stream client error: {e}")
+
+            self._stream_thread = threading.Thread(target=run_stream, daemon=True)
+            self._stream_thread.start()
+
+            logger.info("DingTalk Stream mode started with ChatbotHandler")
+
+        except ImportError as e:
+            logger.warning(
+                "dingtalk-stream SDK not installed. "
+                "Install with: pip install dingtalk-stream"
+            )
+            logger.info("Running in API-only mode without Stream support")
+        except Exception as e:
+            logger.error(f"Failed to start Stream mode: {e}")
+            raise
+
+    async def stop(self) -> None:
+        """Stop the Stream mode connection."""
+        self._running = False
+
+        if self._stream_client:
+            try:
+                self._stream_client.stop()
+            except Exception as e:
+                logger.error(f"Error stopping Stream client: {e}")
+
+        self._stream_client = None
+        self._stream_thread = None
+
+        await self._http_client.aclose()
+        logger.info("DingTalk client stopped")
+
+    async def send_message(
+        self,
+        user_id: str,
+        msg: Dict[str, Any],
+        agent_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a message to a user via DingTalk.
+
+        Args:
+            user_id: The receiver's user ID.
+            msg: Message content dictionary.
+            agent_id: Optional agent ID (uses config default if not provided).
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        agent_id = agent_id or self._config.agent_id
+        if not agent_id:
+            return SendMessageResult(
+                success=False,
+                error="Agent ID is required",
+            )
+
+        token = await self._get_access_token()
+        if not token:
+            return SendMessageResult(
+                success=False,
+                error="Failed to get access token",
+            )
+
+        try:
+            url = f"{DINGTALK_API_BASE}/topapi/message/corpsend"
+            params = {"access_token": token}
+
+            data = {
+                "agent_id": agent_id,
+                "userid_list": user_id,
+                "msg": msg,
+            }
+
+            response = await self._http_client.post(url, params=params, json=data)
+            result = response.json()
+
+            if result.get("errcode") == 0:
+                return SendMessageResult(
+                    success=True,
+                    message_id=result.get("task_id"),
+                )
+            else:
+                return SendMessageResult(
+                    success=False,
+                    error=result.get("errmsg", "Unknown error"),
+                )
+
+        except Exception as e:
+            logger.error(f"Error sending message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    async def send_private_message(
+        self,
+        user_id: str,
+        msg: Dict[str, Any],
+    ) -> SendMessageResult:
+        """Send a private message to a user.
+
+        Args:
+            user_id: The receiver's user ID.
+            msg: Message content dictionary.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        token = await self._get_access_token()
+        if not token:
+            return SendMessageResult(
+                success=False,
+                error="Failed to get access token",
+            )
+
+        try:
+            url = f"{DINGTALK_TOP_API_BASE}/v1.0/robot/oToMessages/batchSend"
+
+            headers = {"x-acs-dingtalk-access-token": token}
+
+            data = {
+                "robotCode": self._config.app_id,
+                "userIds": [user_id],
+                "msgKey": msg.get("msgKey", "sampleText"),
+                "msgParam": msg.get("msgParam", "{}"),
+            }
+
+            response = await self._http_client.post(url, headers=headers, json=data)
+            result = response.json()
+
+            if result.get("processQueryKeys"):
+                return SendMessageResult(
+                    success=True,
+                    message_id=result.get("processQueryKeys", [None])[0],
+                )
+            else:
+                return SendMessageResult(
+                    success=False,
+                    error=str(result),
+                )
+
+        except Exception as e:
+            logger.error(f"Error sending private message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    async def send_group_message(
+        self,
+        conversation_id: str,
+        msg: Dict[str, Any],
+    ) -> SendMessageResult:
+        """Send a message to a group conversation.
+
+        Args:
+            conversation_id: The conversation ID (open_conversation_id).
+            msg: Message content dictionary.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        token = await self._get_access_token()
+        if not token:
+            return SendMessageResult(
+                success=False,
+                error="Failed to get access token",
+            )
+
+        try:
+            url = f"{DINGTALK_TOP_API_BASE}/v1.0/robot/groupMessages/send"
+
+            headers = {"x-acs-dingtalk-access-token": token}
+
+            data = {
+                "robotCode": self._config.app_id,
+                "openConversationId": conversation_id,
+                "msgKey": msg.get("msgKey", "sampleText"),
+                "msgParam": msg.get("msgParam", "{}"),
+            }
+
+            response = await self._http_client.post(url, headers=headers, json=data)
+            result = response.json()
+
+            if result.get("processQueryKey"):
+                return SendMessageResult(
+                    success=True,
+                    message_id=result.get("processQueryKey"),
+                )
+            else:
+                return SendMessageResult(
+                    success=False,
+                    error=str(result),
+                )
+
+        except Exception as e:
+            logger.error(f"Error sending group message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    async def get_user_info(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """Get user information by user ID.
+
+        Args:
+            user_id: The user ID.
+
+        Returns:
+            User information dictionary or None if not found.
+        """
+        token = await self._get_access_token()
+        if not token:
+            return None
+
+        try:
+            url = f"{DINGTALK_API_BASE}/topapi/v2/user/get"
+            params = {"access_token": token}
+
+            data = {"userid": user_id}
+
+            response = await self._http_client.post(url, params=params, json=data)
+            result = response.json()
+
+            if result.get("errcode") == 0:
+                user_info = result.get("result", {})
+                return {
+                    "user_id": user_info.get("userid"),
+                    "name": user_info.get("name"),
+                    "avatar": user_info.get("avatar"),
+                    "mobile": user_info.get("mobile"),
+                    "email": user_info.get("email"),
+                    "department_ids": user_info.get("dept_id_list", []),
+                }
+            return None
+
+        except Exception as e:
+            logger.error(f"Error getting user info: {e}")
+            return None
+
+    async def get_bot_info(self) -> Optional[Dict[str, Any]]:
+        """Get bot information.
+
+        Returns:
+            Bot information dictionary or None if failed.
+        """
+        token = await self._get_access_token()
+        if not token:
+            return None
+
+        try:
+            return {
+                "app_id": self._config.app_id,
+                "agent_id": self._config.agent_id,
+            }
+        except Exception as e:
+            logger.error(f"Error getting bot info: {e}")
+            return None
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the client is connected."""
+        return self._running

--- a/packages/derisk-ext/src/derisk_ext/channels/dingtalk/handler.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/dingtalk/handler.py
@@ -1,0 +1,412 @@
+"""DingTalk channel handler implementation.
+
+This module provides the channel handler implementation for DingTalk
+using Stream mode for receiving messages.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import logging
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional
+
+from derisk.channel.base import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelConnectionState,
+    ChannelHandler,
+    ChannelMessage,
+    ChannelType,
+    SendMessageResult,
+)
+from derisk.channel.schemas import DingTalkConfig
+
+from .client import DingTalkClient
+from .models import DingTalkEventType
+from .sender import DingTalkSender
+
+logger = logging.getLogger(__name__)
+
+
+class DingTalkChannelHandler(ChannelHandler):
+    """Channel handler for DingTalk platform.
+
+    This handler implements the ChannelHandler interface for DingTalk,
+    supporting:
+    - Stream mode for receiving messages (no public URL needed)
+    - Sending various message types
+    - Message parsing and routing
+    """
+
+    @classmethod
+    def get_default_capabilities(cls) -> ChannelCapabilities:
+        """Get default capabilities for DingTalk channel type.
+
+        Returns:
+            ChannelCapabilities describing DingTalk's features.
+        """
+        return ChannelCapabilities(
+            chat_types=["private", "group"],
+            threads=False,
+            media=["text", "image", "file", "voice", "link"],
+            reactions=False,
+            edit=False,
+            reply=True,
+        )
+
+    def __init__(
+        self,
+        channel_id: str,
+        config: ChannelConfig,
+        platform_config: Optional[DingTalkConfig] = None,
+        message_callback: Optional[Callable[[ChannelMessage], None]] = None,
+    ):
+        """Initialize the DingTalk channel handler.
+
+        Args:
+            channel_id: The unique channel identifier.
+            config: Base channel configuration.
+            platform_config: DingTalk-specific configuration.
+            message_callback: Optional callback for received messages.
+        """
+        super().__init__(channel_id, config)
+        self._platform_config = platform_config
+        self._message_callback = message_callback
+        self._client: Optional[DingTalkClient] = None
+        self._sender: Optional[DingTalkSender] = None
+        self._running = False
+
+        if platform_config:
+            self._initialize_client()
+
+    def _initialize_client(self) -> None:
+        """Initialize the DingTalk client."""
+        if not self._platform_config:
+            return
+
+        self._client = DingTalkClient(
+            config=self._platform_config,
+            message_callback=self._on_message_received,
+        )
+        self._sender = DingTalkSender(self._client)
+        logger.info(f"DingTalk client initialized for channel: {self._channel_id}")
+
+    async def start(self) -> None:
+        """Start the channel handler.
+
+        This establishes the Stream mode connection and starts listening
+        for incoming messages.
+        """
+        if self._running:
+            logger.warning("Handler is already running")
+            return
+
+        if not self._client:
+            logger.error("Client not initialized")
+            self._connection_state = ChannelConnectionState.ERROR
+            return
+
+        self._connection_state = ChannelConnectionState.CONNECTING
+        self._running = True
+
+        try:
+            await self._client.start()
+            self._connection_state = ChannelConnectionState.CONNECTED
+            logger.info(f"DingTalk handler started for channel: {self._channel_id}")
+        except Exception as e:
+            logger.error(f"Failed to start DingTalk handler: {e}")
+            self._connection_state = ChannelConnectionState.ERROR
+            self._running = False
+
+    async def stop(self) -> None:
+        """Stop the channel handler.
+
+        This closes the Stream connection and stops listening for messages.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+
+        if self._client:
+            await self._client.stop()
+
+        self._connection_state = ChannelConnectionState.DISCONNECTED
+        logger.info(f"DingTalk handler stopped for channel: {self._channel_id}")
+
+    async def send_message(
+        self,
+        receiver_id: str,
+        content: str,
+        content_type: str = "text",
+        **kwargs,
+    ) -> SendMessageResult:
+        """Send a message to a receiver.
+
+        Args:
+            receiver_id: The receiver ID (user or conversation).
+            content: The message content.
+            content_type: Content type (text, markdown, etc.).
+            **kwargs: Additional parameters.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        if not self._sender:
+            return SendMessageResult(
+                success=False,
+                error="Sender not initialized",
+            )
+
+        is_group = kwargs.get("is_group", False)
+        conversation_id = kwargs.get("conversation_id")
+        mentions = kwargs.get("mentions", [])
+
+        try:
+            if content_type == "markdown":
+                title = kwargs.get("title", "")
+                return await self._sender.send_markdown(
+                    user_id=receiver_id,
+                    title=title,
+                    markdown_content=content,
+                    is_group=is_group,
+                    conversation_id=conversation_id,
+                )
+            elif content_type == "actionCard":
+                btns = kwargs.get("btns", [])
+                title = kwargs.get("title", "")
+                return await self._sender.send_action_card(
+                    user_id=receiver_id,
+                    title=title,
+                    text=content,
+                    btns=btns,
+                    is_group=is_group,
+                    conversation_id=conversation_id,
+                )
+            elif mentions:
+                return await self._sender.send_text_with_mentions(
+                    user_id=receiver_id,
+                    text=content,
+                    mentions=mentions,
+                    is_group=is_group,
+                    conversation_id=conversation_id,
+                )
+            else:
+                return await self._sender.send_text(
+                    user_id=receiver_id,
+                    text=content,
+                    is_group=is_group,
+                    conversation_id=conversation_id or receiver_id,
+                )
+
+        except Exception as e:
+            logger.error(f"Error sending message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    def get_connection_url(self) -> Optional[str]:
+        """Get the webhook URL.
+
+        Returns None since DingTalk uses Stream mode, not webhooks.
+        """
+        return None
+
+    async def process_message(
+        self,
+        channel_id: str,
+        message: ChannelMessage,
+    ) -> Optional[str]:
+        """Process an incoming channel message.
+
+        Args:
+            channel_id: The channel configuration ID.
+            message: The incoming message.
+
+        Returns:
+            Optional response message to send back.
+        """
+        if self._message_callback:
+            try:
+                await asyncio.to_thread(self._message_callback, message)
+            except Exception as e:
+                logger.error(f"Error in message callback: {e}")
+
+        return None
+
+    def validate_signature(
+        self,
+        channel_id: str,
+        signature: str,
+        timestamp: str,
+        nonce: str,
+        body: bytes,
+    ) -> bool:
+        """Validate the webhook signature.
+
+        This is not needed for Stream mode but is kept for compatibility.
+
+        Args:
+            channel_id: The channel configuration ID.
+            signature: The signature from the request header.
+            timestamp: The timestamp from the request.
+            nonce: The nonce from the request.
+            body: The raw request body bytes.
+
+        Returns:
+            True if the signature is valid, False otherwise.
+        """
+        if not self._platform_config:
+            return True
+
+        token = self._platform_config.token
+
+        if not token:
+            return True
+
+        try:
+            string_to_sign = "".join(sorted([timestamp, nonce, token]))
+            expected_signature = hashlib.sha256(string_to_sign.encode()).hexdigest()
+
+            return hmac.compare_digest(signature, expected_signature)
+        except Exception as e:
+            logger.error(f"Error validating signature: {e}")
+            return False
+
+    def get_capabilities(self) -> ChannelCapabilities:
+        """Get DingTalk channel capabilities.
+
+        Returns:
+            ChannelCapabilities describing DingTalk's features.
+        """
+        return self.get_default_capabilities()
+
+    async def test_connection(self, channel_id: str) -> bool:
+        """Test the connection to DingTalk.
+
+        Args:
+            channel_id: The channel configuration ID.
+
+        Returns:
+            True if connection is successful, False otherwise.
+        """
+        if not self._client:
+            return False
+
+        try:
+            bot_info = await self._client.get_bot_info()
+            return bot_info is not None
+        except Exception as e:
+            logger.error(f"Connection test failed: {e}")
+            return False
+
+    def _on_message_received(self, event_dict: Dict[str, Any]) -> None:
+        """Handle received Stream event.
+
+        Args:
+            event_dict: The parsed event dictionary from Stream mode.
+        """
+        try:
+            event_type = event_dict.get("event_type")
+
+            if event_type == DingTalkEventType.CHATBOT_MESSAGE.value:
+                channel_message = self._parse_chatbot_message_event(event_dict)
+                if channel_message and self._message_callback:
+                    try:
+                        self._message_callback(channel_message)
+                    except Exception as e:
+                        logger.error(f"Error in message callback: {e}")
+            else:
+                logger.warning("Received unknown event type: %s", event_type)
+
+        except Exception as e:
+            logger.error(f"Error processing received event: {e}")
+
+    def _parse_chatbot_message_event(
+        self, event_dict: Dict[str, Any]
+    ) -> Optional[ChannelMessage]:
+        """Parse chatbot_message event from ChatbotHandler.
+
+        Args:
+            event_dict: The chatbot_message event dictionary.
+
+        Returns:
+            ChannelMessage or None if parsing fails.
+        """
+        try:
+            sender_id = event_dict.get("sender_id", "")
+            sender_nick = event_dict.get("sender_nick", "")
+            sender_staff_id = event_dict.get("sender_staff_id", "")
+
+            message_id = event_dict.get("message_id", "")
+            conversation_id = event_dict.get("conversation_id", "")
+            conversation_type = event_dict.get("conversation_type", "private")
+            is_group = conversation_type == "group"
+
+            text_content = event_dict.get("text", "")
+
+            timestamp = None
+            create_at = event_dict.get("create_at")
+            if create_at:
+                try:
+                    timestamp = datetime.fromtimestamp(int(create_at) / 1000)
+                except (ValueError, TypeError):
+                    pass
+
+            mentions = None
+            at_users = event_dict.get("at_users", [])
+            if at_users:
+                mentions = [
+                    user.get("dingtalkId", user.get("staffId", ""))
+                    for user in at_users
+                    if user.get("dingtalkId") or user.get("staffId")
+                ]
+
+            return ChannelMessage(
+                channel_type=ChannelType.DINGTALK,
+                message_id=message_id,
+                conversation_id=conversation_id,
+                sender={
+                    "user_id": sender_staff_id or sender_id,
+                    "name": sender_nick,
+                    "extra": {
+                        "sender_id": sender_id,
+                        "sender_staff_id": sender_staff_id,
+                    },
+                },
+                content=text_content,
+                content_type=event_dict.get("message_type", "text"),
+                timestamp=timestamp,
+                is_group=is_group,
+                mentions=mentions,
+                extra={
+                    "raw_event": event_dict,
+                    "robot_code": event_dict.get("robot_code"),
+                    "session_webhook": event_dict.get("session_webhook"),
+                    "is_in_at_list": event_dict.get("is_in_at_list"),
+                },
+            )
+
+        except Exception as e:
+            logger.error(f"Error parsing chatbot_message event: {e}")
+            return None
+
+    def set_message_callback(self, callback: Callable[[ChannelMessage], None]) -> None:
+        """Set the message callback.
+
+        Args:
+            callback: The callback function for received messages.
+        """
+        self._message_callback = callback
+
+    @property
+    def client(self) -> Optional[DingTalkClient]:
+        """Get the DingTalk client."""
+        return self._client
+
+    @property
+    def sender(self) -> Optional[DingTalkSender]:
+        """Get the DingTalk sender."""
+        return self._sender

--- a/packages/derisk-ext/src/derisk_ext/channels/dingtalk/models.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/dingtalk/models.py
@@ -1,0 +1,99 @@
+"""DingTalk event and message models.
+
+This module defines Pydantic models for DingTalk events and messages.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from derisk._private.pydantic import BaseModel, ConfigDict, Field
+
+
+class DingTalkEventType(str, Enum):
+    """DingTalk event type enumeration."""
+
+    # Robot message event from ChatbotHandler (private chat or group @mention)
+    CHATBOT_MESSAGE = "chatbot_message"
+
+
+class DingTalkMessageType(str, Enum):
+    """DingTalk message type enumeration."""
+
+    TEXT = "text"
+    MARKDOWN = "markdown"
+    ACTION_CARD = "actionCard"
+    IMAGE = "picture"
+    FILE = "file"
+    LINK = "link"
+    OA = "oa"
+
+
+class DingTalkChatType(str, Enum):
+    """DingTalk chat type enumeration."""
+
+    PRIVATE = "private"
+    GROUP = "group"
+
+
+class DingTalkMessageContent(BaseModel):
+    """DingTalk message content."""
+
+    model_config = ConfigDict(title="DingTalkMessageContent")
+
+    content: str = Field(default="", description="Message content")
+    title: Optional[str] = Field(default=None, description="Message title")
+
+
+class DingTalkTextMessage(BaseModel):
+    """DingTalk text message to send."""
+
+    model_config = ConfigDict(title="DingTalkTextMessage")
+
+    msgtype: str = Field(default="text", description="Message type")
+    text: Dict[str, Any] = Field(
+        default_factory=lambda: {"content": ""},
+        description="Text content",
+    )
+
+
+class DingTalkMarkdownMessage(BaseModel):
+    """DingTalk markdown message to send."""
+
+    model_config = ConfigDict(title="DingTalkMarkdownMessage")
+
+    msgtype: str = Field(default="markdown", description="Message type")
+    markdown: Dict[str, Any] = Field(
+        default_factory=lambda: {"title": "", "text": ""},
+        description="Markdown content",
+    )
+
+
+class DingTalkActionCardMessage(BaseModel):
+    """DingTalk action card message to send."""
+
+    model_config = ConfigDict(title="DingTalkActionCardMessage")
+
+    msgtype: str = Field(default="actionCard", description="Message type")
+    actionCard: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Action card content",
+    )
+
+
+class DingTalkAtUser(BaseModel):
+    """DingTalk @mention user info."""
+
+    model_config = ConfigDict(title="DingTalkAtUser")
+
+    dingtalkId: str = Field(..., description="User DingTalk ID")
+    staffId: Optional[str] = Field(default=None, description="Staff ID")
+
+
+class DingTalkSendResult(BaseModel):
+    """DingTalk message send result."""
+
+    model_config = ConfigDict(title="DingTalkSendResult")
+
+    errcode: int = Field(default=0, description="Error code")
+    errmsg: str = Field(default="", description="Error message")
+    msgid: Optional[str] = Field(default=None, description="Message ID")

--- a/packages/derisk-ext/src/derisk_ext/channels/dingtalk/sender.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/dingtalk/sender.py
@@ -1,0 +1,386 @@
+"""DingTalk message sender.
+
+This module provides a sender class for sending various types of messages
+through the DingTalk platform.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from derisk.channel.base import SendMessageResult
+
+from .client import DingTalkClient
+
+logger = logging.getLogger(__name__)
+
+
+class DingTalkSender:
+    """Message sender for DingTalk platform.
+
+    This class provides methods for sending different types of messages
+    including text, markdown, and actionCard messages.
+    """
+
+    def __init__(self, client: DingTalkClient):
+        """Initialize the sender.
+
+        Args:
+            client: The DingTalk client instance.
+        """
+        self._client = client
+
+    async def send_text(
+        self,
+        user_id: str,
+        text: str,
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a text message.
+
+        Args:
+            user_id: The receiver's user ID (or conversation ID for groups).
+            text: The text content.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": "sampleText",
+            "msgParam": json.dumps({"content": text}),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def send_markdown(
+        self,
+        user_id: str,
+        title: str,
+        markdown_content: str,
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a markdown message.
+
+        Args:
+            user_id: The receiver's user ID.
+            title: The message title.
+            markdown_content: The markdown content.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": "sampleMarkdown",
+            "msgParam": json.dumps(
+                {
+                    "title": title,
+                    "text": markdown_content,
+                }
+            ),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def send_action_card(
+        self,
+        user_id: str,
+        title: str,
+        text: str,
+        btns: List[Dict[str, str]],
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+        btn_orientation: str = "0",
+    ) -> SendMessageResult:
+        """Send an actionCard message.
+
+        Args:
+            user_id: The receiver's user ID.
+            title: The card title.
+            text: The card text (markdown supported).
+            btns: List of button dictionaries with 'title' and 'actionURL' keys.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+            btn_orientation: Button orientation ("0" vertical, "1" horizontal).
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": "sampleActionCard",
+            "msgParam": json.dumps(
+                {
+                    "title": title,
+                    "text": text,
+                    "btnOrientation": btn_orientation,
+                    "btnJsonList": btns,
+                }
+            ),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def send_image(
+        self,
+        user_id: str,
+        photo_url: str,
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send an image message.
+
+        Args:
+            user_id: The receiver's user ID.
+            photo_url: The image URL.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": "sampleImageMsg",
+            "msgParam": json.dumps({"photoURL": photo_url}),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def send_link(
+        self,
+        user_id: str,
+        title: str,
+        text: str,
+        message_url: str,
+        pic_url: Optional[str] = None,
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a link message.
+
+        Args:
+            user_id: The receiver's user ID.
+            title: The link title.
+            text: The link text.
+            message_url: The link URL.
+            pic_url: Optional picture URL.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content: Dict[str, Any] = {
+            "title": title,
+            "text": text,
+            "messageUrl": message_url,
+        }
+        if pic_url:
+            content["picUrl"] = pic_url
+
+        msg = {
+            "msgKey": "sampleLink",
+            "msgParam": json.dumps(content),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def reply_text(
+        self,
+        message_id: str,
+        text: str,
+        conversation_id: str,
+        is_group: bool = True,
+    ) -> SendMessageResult:
+        """Reply to a message with text.
+
+        This uses the group/private message API to send a reply.
+
+        Args:
+            message_id: The original message ID.
+            text: The reply text.
+            conversation_id: The conversation ID.
+            is_group: Whether this is a group message.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        return await self.send_text(
+            user_id="",
+            text=text,
+            is_group=is_group,
+            conversation_id=conversation_id,
+        )
+
+    async def send_text_with_mentions(
+        self,
+        user_id: str,
+        text: str,
+        mentions: List[str],
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a text message with user mentions.
+
+        Args:
+            user_id: The receiver's user ID.
+            text: The text content.
+            mentions: List of user IDs to mention.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        mention_text = text
+        for user_id_mention in mentions:
+            mention_text = f"@{user_id_mention} {mention_text}"
+
+        return await self.send_text(
+            user_id=user_id,
+            text=mention_text,
+            is_group=is_group,
+            conversation_id=conversation_id,
+        )
+
+    async def send_oa_message(
+        self,
+        user_id: str,
+        title: str,
+        content: List[Dict[str, Any]],
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send an OA (Office Automation) style message.
+
+        Args:
+            user_id: The receiver's user ID.
+            title: The message title.
+            content: List of content rows.
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": "sampleOA",
+            "msgParam": json.dumps(
+                {
+                    "head": {
+                        "bgcolor": "FFBBBBBB",
+                        "text": "header",
+                    },
+                    "body": {
+                        "title": title,
+                        "form": content,
+                        "rich": {
+                            "label": {"content": "", "text": ""},
+                        },
+                    },
+                }
+            ),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )
+
+    async def send_file(
+        self,
+        user_id: str,
+        media_id: str,
+        file_name: str,
+        file_type: str = "file",
+        is_group: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> SendMessageResult:
+        """Send a file message.
+
+        Args:
+            user_id: The receiver's user ID.
+            media_id: The media ID from DingTalk upload.
+            file_name: The file name.
+            file_type: The file type (file, voice, video, etc.).
+            is_group: Whether to send to a group.
+            conversation_id: The conversation ID for group messages.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        msg = {
+            "msgKey": f"sample{file_type.capitalize()}",
+            "msgParam": json.dumps(
+                {
+                    "media_id": media_id,
+                    "file_name": file_name,
+                }
+            ),
+        }
+
+        if is_group and conversation_id:
+            return await self._client.send_group_message(
+                conversation_id=conversation_id,
+                msg=msg,
+            )
+        else:
+            return await self._client.send_private_message(
+                user_id=user_id,
+                msg=msg,
+            )

--- a/packages/derisk-ext/src/derisk_ext/channels/feishu/__init__.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/feishu/__init__.py
@@ -1,0 +1,15 @@
+"""Feishu channel implementation.
+
+This module provides a complete implementation for Feishu/Lark integration
+using the official lark-oapi SDK with WebSocket mode for receiving messages.
+"""
+
+from derisk_ext.channels.feishu.client import FeishuClient
+from derisk_ext.channels.feishu.handler import FeishuChannelHandler
+from derisk_ext.channels.feishu.sender import FeishuSender
+
+__all__ = [
+    "FeishuClient",
+    "FeishuChannelHandler",
+    "FeishuSender",
+]

--- a/packages/derisk-ext/src/derisk_ext/channels/feishu/client.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/feishu/client.py
@@ -1,0 +1,423 @@
+"""Feishu API client using lark-oapi SDK.
+
+This module provides a client for interacting with Feishu/Lark APIs
+using the official lark-oapi Python SDK with WebSocket support.
+"""
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from derisk.channel.base import SendMessageResult
+from derisk.channel.schemas import FeishuConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    import lark_oapi as lark
+    from lark_oapi.api.im.v1 import (
+        CreateMessageRequest,
+        CreateMessageRequestBody,
+        GetChatRequest,
+        GetMessageRequest,
+    )
+
+    LARK_SDK_AVAILABLE = True
+except ImportError:
+    LARK_SDK_AVAILABLE = False
+    lark = None
+    logger.warning("lark-oapi SDK not installed. Install with: pip install lark-oapi")
+
+
+class FeishuClient:
+    """Feishu API client using lark-oapi SDK.
+
+    This client handles:
+    - Authentication and token management
+    - WebSocket connection for receiving events
+    - Message sending and receiving
+    - User and conversation information retrieval
+    """
+
+    def __init__(
+        self,
+        config: FeishuConfig,
+        message_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ):
+        """Initialize the Feishu client.
+
+        Args:
+            config: Feishu configuration.
+            message_callback: Optional callback for received messages.
+        """
+        if not LARK_SDK_AVAILABLE:
+            raise ImportError(
+                "lark-oapi SDK is required for Feishu integration. "
+                "Install with: pip install lark-oapi"
+            )
+
+        self._config = config
+        self._message_callback = message_callback
+        self._client: Optional[Any] = None
+        self._ws_client: Optional[Any] = None
+        self._running = False
+
+        domain = lark.FEISHU_DOMAIN if config.domain == "feishu" else lark.LARK_DOMAIN
+
+        self._client = (
+            lark.Client.builder()
+            .app_id(config.app_id)
+            .app_secret(config.app_secret)
+            .domain(domain)
+            .log_level(lark.LogLevel.DEBUG)
+            .build()
+        )
+
+        logger.info(f"FeishuClient initialized for app_id: {config.app_id}")
+
+    async def start(self) -> None:
+        """Start the WebSocket connection for receiving events."""
+        if self._running:
+            logger.warning("Feishu client is already running")
+            return
+
+        self._running = True
+        await self._connect_websocket()
+
+    async def stop(self) -> None:
+        """Stop the WebSocket connection."""
+        self._running = False
+        if self._ws_client:
+            try:
+                self._ws_client.close()
+            except Exception as e:
+                logger.error(f"Error closing WebSocket: {e}")
+        self._ws_client = None
+        logger.info("Feishu client stopped")
+
+    async def _connect_websocket(self) -> None:
+        """Establish WebSocket connection for receiving events."""
+        if not LARK_SDK_AVAILABLE:
+            return
+
+        def do_p2_im_message_receive_v1(data: Any) -> None:
+            """Handle receiving message event."""
+            try:
+                if self._message_callback:
+                    event_dict = {
+                        "event_type": "im.message.receive_v1",
+                        "event_id": data.header.event_id,
+                        "body": data.event.model_dump() if hasattr(data.event, 'model_dump') else data.event,
+                        "raw": data,
+                    }
+                    asyncio.create_task(
+                        asyncio.to_thread(self._message_callback, event_dict)
+                    )
+            except Exception as e:
+                logger.error(f"Error processing message event: {e}")
+
+        try:
+            event_handler = (
+                lark.EventDispatcherHandler.builder(
+                    self._config.verification_token or "",
+                    self._config.encrypt_key or ""
+                )
+                .register_p2_im_message_receive_v1(do_p2_im_message_receive_v1)
+                .build()
+            )
+
+            self._ws_client = lark.ws.Client(
+                self._config.app_id,
+                self._config.app_secret,
+                event_handler=event_handler,
+                domain=lark.FEISHU_DOMAIN if self._config.domain == "feishu" else lark.LARK_DOMAIN,
+                log_level=lark.LogLevel.DEBUG
+            )
+            self._ws_client.start()
+            logger.info("WebSocket connection established")
+        except Exception as e:
+            logger.error(f"Failed to connect WebSocket: {e}")
+            self._running = False
+
+    async def send_message(
+        self,
+        receive_id: str,
+        content: str,
+        msg_type: str = "text",
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a message to a user or chat.
+
+        Args:
+            receive_id: The receiver ID (user_id, chat_id, or open_id).
+            content: The message content.
+            msg_type: Message type (text, post, image, etc.).
+            receive_id_type: Type of receive_id (chat_id, open_id, user_id).
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        if not self._client:
+            return SendMessageResult(
+                success=False,
+                error="Client not initialized",
+            )
+
+        try:
+            request = (
+                CreateMessageRequest.builder()
+                .receive_id_type(receive_id_type)
+                .request_body(
+                    CreateMessageRequestBody.builder()
+                    .receive_id(receive_id)
+                    .msg_type(msg_type)
+                    .content(content)
+                    .build()
+                )
+                .build()
+            )
+
+            response = self._client.im.v1.message.create(request)
+
+            if response.success():
+                return SendMessageResult(
+                    success=True,
+                    message_id=response.data.message_id,
+                )
+            else:
+                return SendMessageResult(
+                    success=False,
+                    error=f"API error: {response.msg}",
+                )
+
+        except Exception as e:
+            logger.error(f"Error sending message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    async def send_text_message(
+        self,
+        receive_id: str,
+        text: str,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a text message.
+
+        Args:
+            receive_id: The receiver ID.
+            text: The text content.
+            receive_id_type: Type of receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        import json
+
+        content = json.dumps({"text": text})
+        return await self.send_message(
+            receive_id=receive_id,
+            content=content,
+            msg_type="text",
+            receive_id_type=receive_id_type,
+        )
+
+    async def send_interactive_card(
+        self,
+        receive_id: str,
+        title: str,
+        content: str,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send an interactive card message.
+
+        Args:
+            receive_id: The receiver ID.
+            title: Card title.
+            content: Card content (markdown supported).
+            receive_id_type: Type of receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        import json
+
+        card_content = {
+            "type": "template",
+            "data": {
+                "template_id": "AAqk3gJ",  # Default template
+                "template_variable": {
+                    "title": title,
+                    "content": content,
+                },
+            },
+        }
+
+        return await self.send_message(
+            receive_id=receive_id,
+            content=json.dumps(card_content),
+            msg_type="interactive",
+            receive_id_type=receive_id_type,
+        )
+
+    async def reply_message(
+        self,
+        message_id: str,
+        content: str,
+        msg_type: str = "text",
+    ) -> SendMessageResult:
+        """Reply to a message.
+
+        Args:
+            message_id: The message ID to reply to.
+            content: The reply content.
+            msg_type: Message type.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        if not self._client:
+            return SendMessageResult(
+                success=False,
+                error="Client not initialized",
+            )
+
+        try:
+            request = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(
+                    CreateMessageRequestBody.builder()
+                    .receive_id(message_id)
+                    .msg_type(msg_type)
+                    .content(content)
+                    .build()
+                )
+                .build()
+            )
+
+            response = self._client.im.v1.message.create(request)
+
+            if response.success():
+                return SendMessageResult(
+                    success=True,
+                    message_id=response.data.message_id,
+                )
+            else:
+                return SendMessageResult(
+                    success=False,
+                    error=f"API error: {response.msg}",
+                )
+
+        except Exception as e:
+            logger.error(f"Error replying to message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    async def get_user_info(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """Get user information by user ID.
+
+        Args:
+            user_id: The user ID.
+
+        Returns:
+            User information dictionary or None if not found.
+        """
+        if not self._client:
+            return None
+
+        try:
+            response = self._client.contact.v3.user.get(
+                user_id=user_id,
+                user_id_type="open_id",
+            )
+
+            if response.success():
+                return {
+                    "user_id": response.data.user.user_id,
+                    "name": response.data.user.name,
+                    "avatar": response.data.user.avatar_url,
+                    "department_ids": response.data.user.department_ids,
+                }
+            return None
+
+        except Exception as e:
+            logger.error(f"Error getting user info: {e}")
+            return None
+
+    async def get_bot_info(self) -> Optional[Dict[str, Any]]:
+        """Get bot information for connection test.
+
+        Returns:
+            Bot information dictionary or None if failed.
+        """
+        if not self._client:
+            return None
+
+        try:
+            # Create a client for bot info request
+            domain = lark.FEISHU_DOMAIN if self._config.domain == "feishu" else lark.LARK_DOMAIN
+            client = (
+                lark.Client.builder()
+                .app_id(self._config.app_id)
+                .app_secret(self._config.app_secret)
+                .domain(domain)
+                .build()
+            )
+
+            # Call bot/v3/info API
+            response = client.request(
+                method="GET",
+                url="/open-apis/bot/v3/info",
+            )
+
+            if response.code == 0:
+                bot = response.data.get("bot", {}) if isinstance(response.data, dict) else {}
+                return {
+                    "app_name": bot.get("app_name", self._config.app_id),
+                    "open_id": bot.get("open_id"),
+                    "avatar_url": bot.get("avatar_url"),
+                }
+            logger.error(f"Failed to get bot info: code={response.code}, msg={response.msg}")
+            return None
+        except Exception as e:
+            logger.error(f"Error getting bot info: {e}")
+            return None
+
+    async def get_conversation_info(self, chat_id: str) -> Optional[Dict[str, Any]]:
+        """Get conversation information.
+
+        Args:
+            chat_id: The chat/conversation ID.
+
+        Returns:
+            Conversation information or None if not found.
+        """
+        if not self._client:
+            return None
+
+        try:
+            request = GetChatRequest.builder().chat_id(chat_id).build()
+
+            response = self._client.im.v1.chat.get(request)
+
+            if response.success():
+                return {
+                    "chat_id": response.data.chat_id,
+                    "name": response.data.name,
+                    "chat_mode": getattr(response.data, "chat_mode", None),
+                    "chat_type": getattr(response.data, "chat_type", None),
+                }
+            return None
+
+        except Exception as e:
+            logger.error(f"Error getting conversation info: {e}")
+            return None
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the client is connected."""
+        return self._running and self._ws_client is not None

--- a/packages/derisk-ext/src/derisk_ext/channels/feishu/handler.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/feishu/handler.py
@@ -1,0 +1,459 @@
+"""Feishu channel handler implementation.
+
+This module provides the channel handler implementation for Feishu/Lark
+using WebSocket mode for receiving messages.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional
+
+from derisk.channel.base import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelConnectionState,
+    ChannelHandler,
+    ChannelMessage,
+    ChannelType,
+    SendMessageResult,
+)
+from derisk.channel.schemas import FeishuConfig
+
+from .client import FeishuClient
+from .models import (
+    FeishuEvent,
+    FeishuEventType,
+    FeishuMessageContentType,
+    FeishuMessageEvent,
+    FeishuUrlVerifyEvent,
+)
+from .sender import FeishuSender
+
+logger = logging.getLogger(__name__)
+
+
+class FeishuChannelHandler(ChannelHandler):
+    """Channel handler for Feishu/Lark platform.
+
+    This handler implements the ChannelHandler interface for Feishu,
+    supporting:
+    - WebSocket mode for receiving messages (no public URL needed)
+    - Sending various message types
+    - Message parsing and routing
+    """
+
+    @classmethod
+    def get_default_capabilities(cls) -> ChannelCapabilities:
+        """Get default capabilities for Feishu channel type.
+
+        Returns:
+            ChannelCapabilities describing Feishu's features.
+        """
+        return ChannelCapabilities(
+            chat_types=["private", "group"],
+            threads=True,
+            media=["text", "image", "file", "audio", "video"],
+            reactions=True,
+            edit=True,
+            reply=True,
+        )
+
+    def __init__(
+        self,
+        channel_id: str,
+        config: ChannelConfig,
+        platform_config: Optional[FeishuConfig] = None,
+        message_callback: Optional[Callable[[ChannelMessage], None]] = None,
+    ):
+        """Initialize the Feishu channel handler.
+
+        Args:
+            channel_id: The unique channel identifier.
+            config: Base channel configuration.
+            platform_config: Feishu-specific configuration.
+            message_callback: Optional callback for received messages.
+        """
+        super().__init__(channel_id, config)
+        self._platform_config = platform_config
+        self._message_callback = message_callback
+        self._client: Optional[FeishuClient] = None
+        self._sender: Optional[FeishuSender] = None
+        self._running = False
+
+        if platform_config:
+            self._initialize_client()
+
+    def _initialize_client(self) -> None:
+        """Initialize the Feishu client."""
+        if not self._platform_config:
+            return
+
+        self._client = FeishuClient(
+            config=self._platform_config,
+            message_callback=self._on_message_received,
+        )
+        self._sender = FeishuSender(self._client)
+        logger.info(f"Feishu client initialized for channel: {self._channel_id}")
+
+    async def start(self) -> None:
+        """Start the channel handler.
+
+        This establishes the WebSocket connection and starts listening
+        for incoming messages.
+        """
+        if self._running:
+            logger.warning("Handler is already running")
+            return
+
+        if not self._client:
+            logger.error("Client not initialized")
+            self._connection_state = ChannelConnectionState.ERROR
+            return
+
+        self._connection_state = ChannelConnectionState.CONNECTING
+        self._running = True
+
+        try:
+            await self._client.start()
+            self._connection_state = ChannelConnectionState.CONNECTED
+            logger.info(f"Feishu handler started for channel: {self._channel_id}")
+        except Exception as e:
+            logger.error(f"Failed to start Feishu handler: {e}")
+            self._connection_state = ChannelConnectionState.ERROR
+            self._running = False
+
+    async def stop(self) -> None:
+        """Stop the channel handler.
+
+        This closes the WebSocket connection and stops listening for messages.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+
+        if self._client:
+            await self._client.stop()
+
+        self._connection_state = ChannelConnectionState.DISCONNECTED
+        logger.info(f"Feishu handler stopped for channel: {self._channel_id}")
+
+    async def send_message(
+        self,
+        receiver_id: str,
+        content: str,
+        content_type: str = "text",
+        **kwargs,
+    ) -> SendMessageResult:
+        """Send a message to a receiver.
+
+        Args:
+            receiver_id: The receiver ID (user or chat).
+            content: The message content.
+            content_type: Content type (text, markdown, etc.).
+            **kwargs: Additional parameters.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        if not self._sender:
+            return SendMessageResult(
+                success=False,
+                error="Sender not initialized",
+            )
+
+        reply_to = kwargs.get("reply_to")
+        mentions = kwargs.get("mentions", [])
+
+        try:
+            if content_type == "markdown":
+                return await self._sender.send_markdown(
+                    receive_id=receiver_id,
+                    title="",
+                    markdown_content=content,
+                )
+            elif content_type == "interactive":
+                return await self._sender.send_interactive_card(
+                    receive_id=receiver_id,
+                    title="",
+                    content=content,
+                )
+            elif mentions:
+                return await self._sender.send_text_with_mentions(
+                    receive_id=receiver_id,
+                    text=content,
+                    mention_ids=mentions,
+                )
+            else:
+                if reply_to:
+                    return await self._sender.reply_text(
+                        message_id=reply_to,
+                        text=content,
+                    )
+                else:
+                    return await self._sender.send_text(
+                        receive_id=receiver_id,
+                        text=content,
+                    )
+
+        except Exception as e:
+            logger.error(f"Error sending message: {e}")
+            return SendMessageResult(
+                success=False,
+                error=str(e),
+            )
+
+    def get_connection_url(self) -> Optional[str]:
+        """Get the webhook URL.
+
+        Returns None since Feishu uses WebSocket mode, not webhooks.
+        """
+        return None
+
+    async def process_message(
+        self,
+        channel_id: str,
+        message: ChannelMessage,
+    ) -> Optional[str]:
+        """Process an incoming channel message.
+
+        Args:
+            channel_id: The channel configuration ID.
+            message: The incoming message.
+
+        Returns:
+            Optional response message to send back.
+        """
+        if self._message_callback:
+            try:
+                await asyncio.to_thread(self._message_callback, message)
+            except Exception as e:
+                logger.error(f"Error in message callback: {e}")
+
+        return None
+
+    def validate_signature(
+        self,
+        channel_id: str,
+        signature: str,
+        timestamp: str,
+        nonce: str,
+        body: bytes,
+    ) -> bool:
+        """Validate the webhook signature.
+
+        This is not needed for WebSocket mode but is kept for compatibility.
+
+        Args:
+            channel_id: The channel configuration ID.
+            signature: The signature from the request header.
+            timestamp: The timestamp from the request.
+            nonce: The nonce from the request.
+            body: The raw request body bytes.
+
+        Returns:
+            True if the signature is valid, False otherwise.
+        """
+        if not self._platform_config or not self._platform_config.verification_token:
+            return True
+
+        try:
+            token = self._platform_config.verification_token
+            string_to_sign = f"{timestamp}{nonce}{token}"
+            expected_signature = hashlib.sha256(string_to_sign.encode()).hexdigest()
+
+            return hmac.compare_digest(signature, expected_signature)
+        except Exception as e:
+            logger.error(f"Error validating signature: {e}")
+            return False
+
+    def get_capabilities(self) -> ChannelCapabilities:
+        """Get Feishu channel capabilities.
+
+        Returns:
+            ChannelCapabilities describing Feishu's features.
+        """
+        return self.get_default_capabilities()
+
+    async def test_connection(self, channel_id: str) -> bool:
+        """Test the connection to Feishu.
+
+        Args:
+            channel_id: The channel configuration ID.
+
+        Returns:
+            True if connection is successful, False otherwise.
+        """
+        if not self._client:
+            return False
+
+        try:
+            bot_info = await self._client.get_bot_info()
+            return bot_info is not None
+        except Exception as e:
+            logger.error(f"Connection test failed: {e}")
+            return False
+
+    def _on_message_received(self, event_dict: Dict[str, Any]) -> None:
+        """Handle received WebSocket message.
+
+        Args:
+            event_dict: The parsed event dictionary.
+        """
+        try:
+            event_type = event_dict.get("event_type", "")
+            body = event_dict.get("body", {})
+
+            if event_type == FeishuEventType.MESSAGE_RECEIVE:
+                header = FeishuEventHeader(
+                    event_id=event_dict.get("event_id", ""),
+                    event_type=event_type,
+                    create_time=str(int(datetime.now().timestamp() * 1000)),
+                )
+
+                event = FeishuEvent(header=header, event=body)
+                message_event = event.get_message_event()
+
+                if message_event:
+                    channel_message = self._parse_message_event(message_event)
+                    if channel_message and self._message_callback:
+                        try:
+                            self._message_callback(channel_message)
+                        except Exception as e:
+                            logger.error(f"Error in message callback: {e}")
+
+        except Exception as e:
+            logger.error(f"Error processing received message: {e}")
+
+    def _parse_message_event(
+        self, event: FeishuMessageEvent
+    ) -> Optional[ChannelMessage]:
+        """Parse a Feishu message event into a ChannelMessage.
+
+        Args:
+            event: The Feishu message event.
+
+        Returns:
+            ChannelMessage or None if parsing fails.
+        """
+        try:
+            sender_id = event.sender.sender_id or {}
+            open_id = sender_id.get("open_id", sender_id.get("user_id", ""))
+
+            message = event.message
+            content = self._extract_text_content(message.content, message.message_type)
+
+            is_group = True
+
+            timestamp = None
+            if message.create_time:
+                try:
+                    timestamp = datetime.fromtimestamp(int(message.create_time) / 1000)
+                except (ValueError, TypeError):
+                    pass
+
+            mentions = None
+            if message.mentions:
+                mentions = [
+                    m.get("id", {}).get("open_id", "")
+                    for m in message.mentions
+                    if m.get("id", {}).get("open_id")
+                ]
+
+            return ChannelMessage(
+                channel_type=ChannelType.FEISHU,
+                message_id=message.message_id,
+                conversation_id=message.chat_id,
+                sender={
+                    "user_id": open_id,
+                    "name": "",
+                    "extra": event.sender.model_dump(),
+                },
+                content=content,
+                content_type=message.message_type,
+                timestamp=timestamp,
+                reply_to=message.parent_id,
+                thread_id=message.root_id,
+                is_group=is_group,
+                mentions=mentions,
+                extra={"raw_event": event.model_dump()},
+            )
+
+        except Exception as e:
+            logger.error(f"Error parsing message event: {e}")
+            return None
+
+    def _extract_text_content(self, content: str, content_type: str) -> str:
+        """Extract text content from a Feishu message.
+
+        Args:
+            content: The raw message content (JSON string).
+            content_type: The message type.
+
+        Returns:
+            Extracted text content.
+        """
+        try:
+            if content_type == FeishuMessageContentType.TEXT:
+                data = json.loads(content)
+                return data.get("text", "")
+
+            elif content_type == FeishuMessageContentType.POST:
+                data = json.loads(content)
+                text_parts = []
+                for paragraph in data.get("content", []):
+                    for segment in paragraph:
+                        if segment.get("tag") == "text":
+                            text_parts.append(segment.get("text", ""))
+                return "".join(text_parts)
+
+            else:
+                return f"[{content_type}]"
+
+        except json.JSONDecodeError:
+            return content
+        except Exception as e:
+            logger.error(f"Error extracting text content: {e}")
+            return content
+
+    def set_message_callback(self, callback: Callable[[ChannelMessage], None]) -> None:
+        """Set the message callback.
+
+        Args:
+            callback: The callback function for received messages.
+        """
+        self._message_callback = callback
+
+    @property
+    def client(self) -> Optional[FeishuClient]:
+        """Get the Feishu client."""
+        return self._client
+
+    @property
+    def sender(self) -> Optional[FeishuSender]:
+        """Get the Feishu sender."""
+        return self._sender
+
+
+class FeishuEventHeader:
+    """Simple event header class for parsing."""
+
+    def __init__(
+        self,
+        event_id: str,
+        event_type: str,
+        create_time: str,
+        token: Optional[str] = None,
+        app_id: Optional[str] = None,
+        tenant_key: Optional[str] = None,
+    ):
+        self.event_id = event_id
+        self.event_type = event_type
+        self.create_time = create_time
+        self.token = token
+        self.app_id = app_id
+        self.tenant_key = tenant_key

--- a/packages/derisk-ext/src/derisk_ext/channels/feishu/models.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/feishu/models.py
@@ -1,0 +1,201 @@
+"""Feishu event and message models.
+
+This module defines Pydantic models for Feishu events and messages.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from derisk._private.pydantic import BaseModel, ConfigDict, Field
+
+
+class FeishuEventType(str, Enum):
+    """Feishu event type enumeration."""
+
+    MESSAGE_RECEIVE = "im.message.receive_v1"
+    MESSAGE_READ = "im.message.read_v1"
+    MESSAGE_REACTION = "im.message.reaction.created_v1"
+    BOT_ADDED = "im.chat.member.bot.added_v1"
+    BOT_REMOVED = "im.chat.member.bot.deleted_v1"
+    URL_VERIFY = "url_verification"
+
+
+class FeishuMessageContentType(str, Enum):
+    """Feishu message content type enumeration."""
+
+    TEXT = "text"
+    POST = "post"
+    IMAGE = "image"
+    FILE = "file"
+    AUDIO = "audio"
+    MEDIA = "media"
+    STICKER = "sticker"
+    INTERACTIVE = "interactive"
+    LOCATION = "location"
+    SHARE_CHAT = "share_chat"
+    SHARE_USER = "share_user"
+
+
+class FeishuChatType(str, Enum):
+    """Feishu chat type enumeration."""
+
+    PRIVATE = "p2p"
+    GROUP = "group"
+
+
+class FeishuEventHeader(BaseModel):
+    """Feishu event header."""
+
+    model_config = ConfigDict(title="FeishuEventHeader")
+
+    event_id: str = Field(..., description="Event ID")
+    event_type: str = Field(..., description="Event type")
+    create_time: str = Field(..., description="Event create time")
+    token: Optional[str] = Field(default=None, description="Verification token")
+    app_id: Optional[str] = Field(default=None, description="App ID")
+    tenant_key: Optional[str] = Field(default=None, description="Tenant key")
+
+
+class FeishuSender(BaseModel):
+    """Feishu message sender."""
+
+    model_config = ConfigDict(title="FeishuSender")
+
+    sender_id: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Sender ID with type (open_id, user_id, union_id)",
+    )
+    sender_type: Optional[str] = Field(
+        default=None,
+        description="Sender type (app, user)",
+    )
+    tenant_key: Optional[str] = Field(
+        default=None,
+        description="Tenant key",
+    )
+
+
+class FeishuMessage(BaseModel):
+    """Feishu message content."""
+
+    model_config = ConfigDict(title="FeishuMessage")
+
+    message_id: str = Field(..., description="Message ID")
+    root_id: Optional[str] = Field(default=None, description="Root message ID")
+    parent_id: Optional[str] = Field(default=None, description="Parent message ID")
+    create_time: str = Field(..., description="Message create time")
+    chat_id: str = Field(..., description="Chat ID")
+    message_type: str = Field(..., description="Message type")
+    content: str = Field(..., description="Message content (JSON string)")
+    mentions: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Mentioned users/robots",
+    )
+
+
+class FeishuMessageEvent(BaseModel):
+    """Feishu message receive event."""
+
+    model_config = ConfigDict(title="FeishuMessageEvent")
+
+    sender: FeishuSender = Field(..., description="Message sender")
+    message: FeishuMessage = Field(..., description="Message content")
+
+
+class FeishuEvent(BaseModel):
+    """Feishu event wrapper."""
+
+    model_config = ConfigDict(title="FeishuEvent")
+
+    header: FeishuEventHeader = Field(..., description="Event header")
+    event: Dict[str, Any] = Field(..., description="Event body")
+
+    def get_message_event(self) -> Optional[FeishuMessageEvent]:
+        """Parse message event from the event body.
+
+        Returns:
+            FeishuMessageEvent if this is a message event, None otherwise.
+        """
+        if self.header.event_type == FeishuEventType.MESSAGE_RECEIVE:
+            try:
+                return FeishuMessageEvent(**self.event)
+            except Exception:
+                pass
+        return None
+
+
+class FeishuUrlVerifyEvent(BaseModel):
+    """Feishu URL verification event."""
+
+    model_config = ConfigDict(title="FeishuUrlVerifyEvent")
+
+    challenge: str = Field(..., description="Challenge string to echo back")
+
+
+class FeishuTextContent(BaseModel):
+    """Feishu text message content."""
+
+    model_config = ConfigDict(title="FeishuTextContent")
+
+    text: str = Field(..., description="Text content")
+
+
+class FeishuPostContent(BaseModel):
+    """Feishu post (rich text) message content."""
+
+    model_config = ConfigDict(title="FeishuPostContent")
+
+    title: Optional[str] = Field(default=None, description="Post title")
+    content: List[List[Dict[str, Any]]] = Field(
+        default_factory=list,
+        description="Post content segments",
+    )
+
+
+class FeishuImageContent(BaseModel):
+    """Feishu image message content."""
+
+    model_config = ConfigDict(title="FeishuImageContent")
+
+    image_key: str = Field(..., description="Image key")
+
+
+class FeishuFileContent(BaseModel):
+    """Feishu file message content."""
+
+    model_config = ConfigDict(title="FeishuFileContent")
+
+    file_key: str = Field(..., description="File key")
+    file_name: Optional[str] = Field(default=None, description="File name")
+
+
+class FeishuInteractiveCard(BaseModel):
+    """Feishu interactive card message content."""
+
+    model_config = ConfigDict(title="FeishuInteractiveCard")
+
+    type: str = Field(default="template", description="Card type")
+    template_id: Optional[str] = Field(default=None, description="Template ID")
+    template_variable: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Template variables",
+    )
+    elements: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Card elements",
+    )
+
+
+class FeishuMessageToSend(BaseModel):
+    """Message to send via Feishu API."""
+
+    model_config = ConfigDict(title="FeishuMessageToSend")
+
+    receive_id: str = Field(..., description="Receiver ID")
+    msg_type: str = Field(default="text", description="Message type")
+    content: str = Field(..., description="Message content (JSON string)")
+    receive_id_type: Optional[str] = Field(
+        default="chat_id",
+        description="Receiver ID type",
+    )

--- a/packages/derisk-ext/src/derisk_ext/channels/feishu/sender.py
+++ b/packages/derisk-ext/src/derisk_ext/channels/feishu/sender.py
@@ -1,0 +1,356 @@
+"""Feishu message sender.
+
+This module provides a sender class for sending various types of messages
+through the Feishu platform.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from derisk.channel.base import SendMessageResult
+
+from .client import FeishuClient
+
+logger = logging.getLogger(__name__)
+
+
+class FeishuSender:
+    """Message sender for Feishu platform.
+
+    This class provides methods for sending different types of messages
+    including text, interactive cards, and media messages.
+    """
+
+    def __init__(self, client: FeishuClient):
+        """Initialize the sender.
+
+        Args:
+            client: The Feishu client instance.
+        """
+        self._client = client
+
+    async def send_text(
+        self,
+        receive_id: str,
+        text: str,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a text message.
+
+        Args:
+            receive_id: The receiver ID (chat_id, open_id, or user_id).
+            text: The text content.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        return await self._client.send_text_message(
+            receive_id=receive_id,
+            text=text,
+            receive_id_type=receive_id_type,
+        )
+
+    async def send_post(
+        self,
+        receive_id: str,
+        title: str,
+        content: List[List[Dict[str, Any]]],
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a post (rich text) message.
+
+        Args:
+            receive_id: The receiver ID.
+            title: Post title.
+            content: Post content segments.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        post_content = {"title": title, "content": content}
+        return await self._client.send_message(
+            receive_id=receive_id,
+            content=json.dumps(post_content),
+            msg_type="post",
+            receive_id_type=receive_id_type,
+        )
+
+    async def send_markdown(
+        self,
+        receive_id: str,
+        title: str,
+        markdown_content: str,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a markdown-style post message.
+
+        This converts markdown to Feishu post format.
+
+        Args:
+            receive_id: The receiver ID.
+            title: Post title.
+            markdown_content: Markdown content.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content = self._markdown_to_post_content(markdown_content)
+        return await self.send_post(
+            receive_id=receive_id,
+            title=title,
+            content=content,
+            receive_id_type=receive_id_type,
+        )
+
+    def _markdown_to_post_content(self, markdown: str) -> List[List[Dict[str, Any]]]:
+        """Convert markdown to Feishu post content format.
+
+        This is a simple conversion that handles basic formatting.
+
+        Args:
+            markdown: Markdown text.
+
+        Returns:
+            Feishu post content structure.
+        """
+        paragraphs: List[List[Dict[str, Any]]] = []
+        lines = markdown.split("\n")
+
+        for line in lines:
+            if not line.strip():
+                continue
+
+            segments: List[Dict[str, Any]] = []
+
+            if line.startswith("# "):
+                segments.append(
+                    {
+                        "tag": "text",
+                        "text": line[2:],
+                        "style": ["bold"],
+                    }
+                )
+            elif line.startswith("## "):
+                segments.append(
+                    {
+                        "tag": "text",
+                        "text": line[3:],
+                        "style": ["bold"],
+                    }
+                )
+            elif line.startswith("- "):
+                segments.append(
+                    {
+                        "tag": "text",
+                        "text": "• " + line[2:],
+                    }
+                )
+            elif line.startswith("* ") and line.endswith("*"):
+                segments.append(
+                    {
+                        "tag": "text",
+                        "text": line[2:-1],
+                        "style": ["italic"],
+                    }
+                )
+            elif line.startswith("**") and line.endswith("**"):
+                segments.append(
+                    {
+                        "tag": "text",
+                        "text": line[2:-2],
+                        "style": ["bold"],
+                    }
+                )
+            else:
+                segments.append({"tag": "text", "text": line})
+
+            paragraphs.append(segments)
+
+        return paragraphs
+
+    async def send_interactive_card(
+        self,
+        receive_id: str,
+        title: str,
+        content: str,
+        receive_id_type: str = "chat_id",
+        buttons: Optional[List[Dict[str, Any]]] = None,
+    ) -> SendMessageResult:
+        """Send an interactive card message.
+
+        Args:
+            receive_id: The receiver ID.
+            title: Card title.
+            content: Card content (markdown supported in template).
+            receive_id_type: Type of the receive_id.
+            buttons: Optional list of buttons.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        card: Dict[str, Any] = {
+            "type": "template",
+            "data": {
+                "template_id": "AAqk3gJ",
+                "template_variable": {
+                    "title": title,
+                    "content": content,
+                },
+            },
+        }
+
+        if buttons:
+            card = {
+                "config": {"wide_screen_mode": True},
+                "elements": [
+                    {"tag": "div", "text": {"content": content, "tag": "lark_md"}},
+                    {
+                        "tag": "action",
+                        "actions": [
+                            {
+                                "tag": "button",
+                                "text": {
+                                    "content": btn.get("text", ""),
+                                    "tag": "plain_text",
+                                },
+                                "type": btn.get("type", "primary"),
+                                "value": btn.get("value", {}),
+                            }
+                            for btn in buttons
+                        ],
+                    },
+                ],
+            }
+
+        return await self._client.send_message(
+            receive_id=receive_id,
+            content=json.dumps(card),
+            msg_type="interactive",
+            receive_id_type=receive_id_type,
+        )
+
+    async def send_image(
+        self,
+        receive_id: str,
+        image_key: str,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send an image message.
+
+        Args:
+            receive_id: The receiver ID.
+            image_key: The image key from Feishu.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content = json.dumps({"image_key": image_key})
+        return await self._client.send_message(
+            receive_id=receive_id,
+            content=content,
+            msg_type="image",
+            receive_id_type=receive_id_type,
+        )
+
+    async def send_file(
+        self,
+        receive_id: str,
+        file_key: str,
+        file_name: Optional[str] = None,
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a file message.
+
+        Args:
+            receive_id: The receiver ID.
+            file_key: The file key from Feishu.
+            file_name: Optional file name.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content: Dict[str, Any] = {"file_key": file_key}
+        if file_name:
+            content["file_name"] = file_name
+
+        return await self._client.send_message(
+            receive_id=receive_id,
+            content=json.dumps(content),
+            msg_type="file",
+            receive_id_type=receive_id_type,
+        )
+
+    async def reply_text(
+        self,
+        message_id: str,
+        text: str,
+    ) -> SendMessageResult:
+        """Reply to a message with text.
+
+        Args:
+            message_id: The message ID to reply to.
+            text: The reply text.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content = json.dumps({"text": text})
+        return await self._client.reply_message(
+            message_id=message_id,
+            content=content,
+            msg_type="text",
+        )
+
+    async def send_text_with_mentions(
+        self,
+        receive_id: str,
+        text: str,
+        mention_ids: List[str],
+        receive_id_type: str = "chat_id",
+    ) -> SendMessageResult:
+        """Send a text message with user mentions.
+
+        Args:
+            receive_id: The receiver ID.
+            text: The text content with placeholders for mentions.
+            mention_ids: List of user IDs to mention.
+            receive_id_type: Type of the receive_id.
+
+        Returns:
+            SendMessageResult indicating success or failure.
+        """
+        content_parts: List[Dict[str, Any]] = []
+
+        mentions: List[Dict[str, Any]] = []
+
+        for i, user_id in enumerate(mention_ids):
+            placeholder = f'<at user_id="{user_id}"></at>'
+            mentions.append(
+                {
+                    "key": placeholder,
+                    "id": {"open_id": user_id},
+                    "name": "",
+                }
+            )
+            content_parts.append({"tag": "at", "user_id": user_id})
+            content_parts.append({"tag": "text", "text": " "})
+
+        content_parts.append({"tag": "text", "text": text})
+
+        post_content = {
+            "title": "",
+            "content": [content_parts],
+        }
+
+        return await self._client.send_message(
+            receive_id=receive_id,
+            content=json.dumps(post_content),
+            msg_type="post",
+            receive_id_type=receive_id_type,
+        )

--- a/packages/derisk-serve/src/derisk_serve/agent/agents/chat/agent_chat.py
+++ b/packages/derisk-serve/src/derisk_serve/agent/agents/chat/agent_chat.py
@@ -336,8 +336,9 @@ class AgentChat(BaseComponent, ABC):
                 except Exception as e:
                     logger.exception(f"获取{agent_conv_id}最终消息异常: {str(e)}")
                     final_message = str(e)
+
+            final_report = None
             if callable(chat_call_back):
-                final_report = None
                 try:
                     final_report = await self.memory.user_answer(agent_conv_id)
                 except Exception as e:
@@ -370,6 +371,15 @@ class AgentChat(BaseComponent, ABC):
                     post_action_reports=post_action_reports,
                 )
 
+            # Deliver to channel if configured (handles cron job message delivery)
+            if not err_msg:
+                content = final_report # 只看final_report 不看final_message
+                content = content.lstrip() if content else None
+                if content:
+                    await self._deliver_to_channel_if_configured(
+                        conv_session_id, content
+                    )
+
             # logger.info(f"获取{conv_session_id}最终消息: {final_message}, 异常信息:{err_msg}")
             if not final_message:
                 final_message = ""
@@ -382,6 +392,93 @@ class AgentChat(BaseComponent, ABC):
 
         finally:
             await self.memory.clear(agent_conv_id)
+
+    async def _deliver_to_channel_if_configured(
+        self,
+        conv_session_id: str,
+        content: str,
+    ) -> bool:
+        """Deliver message to channel if configured in conversation extra.
+
+        This method handles automatic message delivery to channels (e.g., DingTalk)
+        when the conversation was initiated from a channel or when a cron job
+        needs to deliver results to a channel.
+
+        The channel info is stored in the conversation's extra field when
+        the conversation is created from a channel message.
+
+        Args:
+            conv_session_id: The conversation session ID.
+            content: The message content to deliver.
+
+        Returns:
+            True if delivered successfully, False otherwise.
+        """
+        if not conv_session_id:
+            return False
+
+        try:
+            # Get channel info from conversation extra
+            conversations = await self.gpts_conversations.get_by_session_id_asc(
+                conv_session_id
+            )
+
+            if not conversations:
+                logger.debug(f"No conversations found for session {conv_session_id}")
+                return False
+
+            # Get the most recent conversation to extract channel info
+            first_conv = conversations[-1]
+            if not first_conv.extra:
+                logger.debug(f"No extra field in conversation {first_conv.conv_id}")
+                return False
+
+            # Parse extra field
+            extra = orjson.loads(first_conv.extra)
+            channel_info = extra.get("channel")
+
+            if not channel_info:
+                logger.debug(f"No channel info in conversation {first_conv.conv_id}")
+                return False
+
+            channel_id = channel_info.get("channel_id")
+            receiver_id = channel_info.get("receiver_id")
+            is_group = channel_info.get("is_group", False)
+
+            if not channel_id or not receiver_id:
+                logger.warning(
+                    f"Incomplete channel info: channel_id={channel_id}, receiver_id={receiver_id}"
+                )
+                return False
+
+            # Get the channel handler from registry
+            from derisk.channel.registry import ChannelHandlerRegistry
+
+            registry = ChannelHandlerRegistry.get_instance()
+            handler = registry.get_handler(channel_id)
+
+            if not handler:
+                logger.warning(f"No active handler for channel {channel_id}")
+                return False
+
+            # Send the message
+            result = await handler.send_message(
+                receiver_id=receiver_id,
+                content=content,
+                content_type="text",
+                is_group=is_group,
+            )
+
+            if result.success:
+                logger.info(f"Delivered message to channel {channel_id}")
+                return True
+            else:
+                logger.error(f"Failed to deliver: {result.error}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Error delivering to channel: {e}")
+            return False
 
     @trace("agent.initialize_conversation", requires=["app_code", "conv_session_id"])
     async def _initialize_conversation(

--- a/packages/derisk-serve/src/derisk_serve/channel/__init__.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/__init__.py
@@ -12,7 +12,9 @@ from .config import (
     SERVE_SERVICE_COMPONENT_NAME,
     ServeConfig,
 )
+from .connection import ChannelConnectionManager
 from .serve import Serve
+from .service.service import Service
 
 __all__ = [
     "APP_NAME",
@@ -23,4 +25,6 @@ __all__ = [
     "SERVE_SERVICE_COMPONENT_NAME",
     "ServeConfig",
     "Serve",
+    "Service",
+    "ChannelConnectionManager",
 ]

--- a/packages/derisk-serve/src/derisk_serve/channel/api/endpoints.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/api/endpoints.py
@@ -267,6 +267,111 @@ async def disable_channel(
         raise HTTPException(status_code=404, detail=str(e))
 
 
+@router.post(
+    "/channels/{channel_id}/start",
+    response_model=Result[dict],
+    dependencies=[Depends(check_api_key)],
+)
+async def start_channel(
+    channel_id: str,
+    service: Service = Depends(get_service),
+) -> Result[dict]:
+    """Start a channel connection.
+
+    Args:
+        channel_id: The channel ID.
+
+    Returns:
+        Result indicating success or failure.
+    """
+    success = await service.start_channel(channel_id)
+    if success:
+        return Result.succ({"started": True, "channel_id": channel_id})
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to start channel {channel_id}",
+        )
+
+
+@router.post(
+    "/channels/{channel_id}/stop",
+    response_model=Result[dict],
+    dependencies=[Depends(check_api_key)],
+)
+async def stop_channel(
+    channel_id: str,
+    service: Service = Depends(get_service),
+) -> Result[dict]:
+    """Stop a channel connection.
+
+    Args:
+        channel_id: The channel ID.
+
+    Returns:
+        Result indicating success or failure.
+    """
+    success = await service.stop_channel(channel_id)
+    if success:
+        return Result.succ({"stopped": True, "channel_id": channel_id})
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to stop channel {channel_id}",
+        )
+
+
+@router.get(
+    "/channels/running",
+    response_model=Result[List[str]],
+    dependencies=[Depends(check_api_key)],
+)
+async def get_running_channels(
+    service: Service = Depends(get_service),
+) -> Result[List[str]]:
+    """Get list of running channel IDs.
+
+    Returns:
+        List of channel IDs that are currently running.
+    """
+    channels = service.get_running_channels()
+    return Result.succ(channels)
+
+
+@router.post(
+    "/channels/start-all",
+    response_model=Result[dict],
+    dependencies=[Depends(check_api_key)],
+)
+async def start_all_channels(
+    service: Service = Depends(get_service),
+) -> Result[dict]:
+    """Start all enabled channels.
+
+    Returns:
+        Result with status for each channel.
+    """
+    results = await service.start_all_channels()
+    return Result.succ(results)
+
+
+@router.post(
+    "/channels/stop-all",
+    response_model=Result[dict],
+    dependencies=[Depends(check_api_key)],
+)
+async def stop_all_channels(
+    service: Service = Depends(get_service),
+) -> Result[dict]:
+    """Stop all running channels.
+
+    Returns:
+        Result with status for each channel.
+    """
+    results = await service.stop_all_channels()
+    return Result.succ(results)
+
+
 # Webhook endpoints (placeholder - actual implementation in derisk-ext)
 @router.post(
     "/webhook/dingtalk/{channel_id}",

--- a/packages/derisk-serve/src/derisk_serve/channel/connection.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/connection.py
@@ -1,0 +1,290 @@
+"""Channel connection manager.
+
+This module manages active channel connections, including:
+- Starting/stopping channels
+- Health monitoring
+- Reconnection handling
+- Message routing
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional, Set
+
+from derisk.channel import (
+    ChannelConfig,
+    ChannelHandler,
+    ChannelHandlerRegistry,
+    ChannelMessage,
+    ChannelMessageRouter,
+    ChannelType,
+)
+from derisk.channel.schemas import DingTalkConfig, FeishuConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelConnectionManager:
+    """Manager for active channel connections.
+
+    This manager handles:
+    - Creating and managing channel handlers
+    - Starting and stopping channels
+    - Health monitoring
+    - Message routing to agents
+    """
+
+    def __init__(self, message_router: Optional[ChannelMessageRouter] = None):
+        """Initialize the connection manager.
+
+        Args:
+            message_router: Optional message router for routing messages to agents.
+        """
+        self._registry = ChannelHandlerRegistry.get_instance()
+        self._message_router = message_router or ChannelMessageRouter()
+        self._running_handlers: Set[str] = set()
+        self._handler_tasks: Dict[str, asyncio.Task] = {}
+        self._started = False
+
+        self._register_channel_handlers()
+
+    def _register_channel_handlers(self) -> None:
+        """Register channel handler factories."""
+        from derisk_ext.channels.dingtalk import DingTalkChannelHandler
+        from derisk_ext.channels.feishu import FeishuChannelHandler
+
+        def create_feishu_handler(
+            channel_id: str, config: ChannelConfig
+        ) -> ChannelHandler:
+            platform_config = None
+            if config.platform_config:
+                platform_config = FeishuConfig(**config.platform_config)
+
+            return FeishuChannelHandler(
+                channel_id=channel_id,
+                config=config,
+                platform_config=platform_config,
+                message_callback=self._create_message_callback(channel_id),
+            )
+
+        def create_dingtalk_handler(
+            channel_id: str, config: ChannelConfig
+        ) -> ChannelHandler:
+            platform_config = None
+            if config.platform_config:
+                platform_config = DingTalkConfig(**config.platform_config)
+
+            return DingTalkChannelHandler(
+                channel_id=channel_id,
+                config=config,
+                platform_config=platform_config,
+                message_callback=self._create_message_callback(channel_id),
+            )
+
+        self._registry.register_factory(ChannelType.FEISHU, create_feishu_handler)
+        self._registry.register_factory(ChannelType.DINGTALK, create_dingtalk_handler)
+
+        logger.info("Channel handlers registered")
+
+    def _create_message_callback(self, channel_id: str):
+        """Create a message callback for a channel.
+
+        Args:
+            channel_id: The channel ID.
+
+        Returns:
+            A callback function for handling messages.
+        """
+        # Capture the current event loop (main event loop)
+        # This is called from an async context, so get_running_loop() works here
+        loop = asyncio.get_running_loop()
+
+        def callback(message: ChannelMessage) -> None:
+            # Use run_coroutine_threadsafe to submit the coroutine to the main event loop
+            # This is necessary because the callback may be called from a thread pool
+            # thread (e.g., via asyncio.to_thread()), which doesn't have an event loop
+            asyncio.run_coroutine_threadsafe(
+                self._handle_message(channel_id, message),
+                loop
+            )
+
+        return callback
+
+    async def _handle_message(self, channel_id: str, message: ChannelMessage) -> None:
+        """Handle an incoming message.
+
+        Args:
+            channel_id: The channel ID.
+            message: The incoming message.
+        """
+        handler = self._registry.get_handler(channel_id)
+        if handler and self._message_router:
+            await self._message_router.route_message(channel_id, message, handler)
+
+    def register_message_handler(self, channel_id: str, message_handler) -> None:
+        """Register a message handler for a specific channel.
+
+        Args:
+            channel_id: The channel ID.
+            message_handler: The message handler.
+        """
+        self._message_router.register_handler(channel_id, message_handler)
+
+    def set_default_message_handler(self, message_handler) -> None:
+        """Set the default message handler.
+
+        Args:
+            message_handler: The default message handler.
+        """
+        self._message_router.set_default_handler(message_handler)
+
+    async def start_channel(
+        self,
+        channel_id: str,
+        channel_type: ChannelType,
+        config: ChannelConfig,
+    ) -> bool:
+        """Start a channel.
+
+        Args:
+            channel_id: The channel ID.
+            channel_type: The channel type.
+            config: The channel configuration.
+
+        Returns:
+            True if started successfully, False otherwise.
+        """
+        if channel_id in self._running_handlers:
+            logger.warning(f"Channel {channel_id} is already running")
+            return True
+
+        handler = self._registry.create_handler(channel_id, channel_type, config)
+        if not handler:
+            logger.error(f"Failed to create handler for channel {channel_id}")
+            return False
+
+        try:
+            await handler.start()
+            self._running_handlers.add(channel_id)
+            logger.info(f"Started channel: {channel_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to start channel {channel_id}: {e}")
+            self._registry.remove_handler(channel_id)
+            return False
+
+    async def stop_channel(self, channel_id: str) -> bool:
+        """Stop a channel.
+
+        Args:
+            channel_id: The channel ID.
+
+        Returns:
+            True if stopped successfully, False otherwise.
+        """
+        if channel_id not in self._running_handlers:
+            logger.warning(f"Channel {channel_id} is not running")
+            return False
+
+        try:
+            await self._registry.stop_handler(channel_id)
+            self._running_handlers.discard(channel_id)
+            logger.info(f"Stopped channel: {channel_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to stop channel {channel_id}: {e}")
+            return False
+
+    async def start_all_channels(self, channels: List[dict]) -> Dict[str, bool]:
+        """Start all enabled channels.
+
+        Args:
+            channels: List of channel configurations from database.
+
+        Returns:
+            Dictionary mapping channel IDs to success status.
+        """
+        results = {}
+        for channel_data in channels:
+            channel_id = channel_data.get("id")
+            channel_type_str = channel_data.get("channel_type")
+            config_dict = channel_data.get("config", {})
+            enabled = channel_data.get("enabled", False)
+
+            if not enabled:
+                results[channel_id] = False
+                continue
+
+            try:
+                channel_type = ChannelType(channel_type_str)
+            except ValueError:
+                logger.error(f"Unknown channel type: {channel_type_str}")
+                results[channel_id] = False
+                continue
+
+            config = ChannelConfig(
+                name=channel_data.get("name", ""),
+                enabled=enabled,
+                platform_config=config_dict,
+            )
+
+            results[channel_id] = await self.start_channel(
+                channel_id, channel_type, config
+            )
+
+        return results
+
+    async def stop_all_channels(self) -> Dict[str, bool]:
+        """Stop all running channels.
+
+        Returns:
+            Dictionary mapping channel IDs to success status.
+        """
+        results = {}
+        for channel_id in list(self._running_handlers):
+            results[channel_id] = await self.stop_channel(channel_id)
+        return results
+
+    def get_running_channels(self) -> List[str]:
+        """Get list of running channel IDs.
+
+        Returns:
+            List of channel IDs that are currently running.
+        """
+        return list(self._running_handlers)
+
+    def get_handler(self, channel_id: str) -> Optional[ChannelHandler]:
+        """Get a handler by channel ID.
+
+        Args:
+            channel_id: The channel ID.
+
+        Returns:
+            The handler instance, or None if not found.
+        """
+        return self._registry.get_handler(channel_id)
+
+    async def start(self) -> None:
+        """Start the connection manager."""
+        if self._started:
+            return
+
+        self._started = True
+        await self._message_router.start()
+        logger.info("Channel connection manager started")
+
+    async def stop(self) -> None:
+        """Stop the connection manager."""
+        if not self._started:
+            return
+
+        await self.stop_all_channels()
+        await self._message_router.stop()
+        self._started = False
+        logger.info("Channel connection manager stopped")
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the manager is running."""
+        return self._started

--- a/packages/derisk-serve/src/derisk_serve/channel/models/models.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/models/models.py
@@ -25,15 +25,21 @@ class ChannelEntity(Model):
 
     # Basic info
     name = Column(String(255), nullable=False, comment="Channel display name")
-    channel_type = Column(String(32), nullable=False, comment="Channel type (dingtalk/feishu)")
-    enabled = Column(Integer, default=1, comment="Whether channel is enabled (1=yes, 0=no)")
+    channel_type = Column(
+        String(32), nullable=False, comment="Channel type (dingtalk/feishu)"
+    )
+    enabled = Column(
+        Integer, default=1, comment="Whether channel is enabled (1=yes, 0=no)"
+    )
 
     # Platform specific config stored as JSON
     config = Column(JSON, nullable=False, comment="Platform-specific configuration")
 
     # Status
     status = Column(String(32), default="disconnected", comment="Channel status")
-    last_connected = Column(DateTime, nullable=True, comment="Last successful connection time")
+    last_connected = Column(
+        DateTime, nullable=True, comment="Last successful connection time"
+    )
     last_error = Column(Text, nullable=True, comment="Last error message")
 
     # Timestamps
@@ -66,7 +72,9 @@ class ChannelDao(BaseDao[ChannelEntity, ChannelRequest, ChannelResponse]):
         super().__init__()
         self._serve_config = serve_config
 
-    def from_request(self, request: Union[ChannelRequest, Dict[str, Any]]) -> ChannelEntity:
+    def from_request(
+        self, request: Union[ChannelRequest, Dict[str, Any]]
+    ) -> ChannelEntity:
         """Convert a request to an entity.
 
         Args:
@@ -184,4 +192,21 @@ class ChannelDao(BaseDao[ChannelEntity, ChannelRequest, ChannelResponse]):
             List of enabled channel entities.
         """
         with self.session() as session:
-            return session.query(ChannelEntity).filter(ChannelEntity.enabled == 1).all()
+            channels = (
+                session.query(ChannelEntity).filter(ChannelEntity.enabled == 1).all()
+            )
+            # Access all attributes to load them before session closes
+            for ch in channels:
+                _ = ch.id
+                _ = ch.name
+                _ = ch.channel_type
+                _ = ch.config
+                _ = ch.enabled
+                _ = ch.status
+                _ = ch.last_connected
+                _ = ch.last_error
+                _ = ch.gmt_created
+                _ = ch.gmt_modified
+            # Expunge objects from session so they remain usable after session closes
+            session.expunge_all()
+            return channels

--- a/packages/derisk-serve/src/derisk_serve/channel/serve.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/serve.py
@@ -11,6 +11,7 @@ from sqlalchemy import URL
 
 from derisk.component import SystemApp
 from derisk.storage.metadata import DatabaseManager
+from derisk.util.fastapi import register_event_handler
 from derisk_serve.core import BaseServe
 
 from .api.endpoints import init_endpoints, router
@@ -19,6 +20,7 @@ from .config import (
     SERVE_APP_NAME,
     SERVE_APP_NAME_HUMP,
     SERVE_CONFIG_KEY_PREFIX,
+    SERVE_SERVICE_COMPONENT_NAME,
     ServeConfig,
 )
 
@@ -91,13 +93,28 @@ class Serve(BaseServe):
     def before_start(self):
         """Called before the application starts.
 
-        Initialize the service.
+        Register async startup and shutdown handlers to properly
+        start/stop channel connections when the event loop is running.
         """
-        logger.info("Starting channel serve component")
+        logger.info("Registering channel startup/shutdown handlers")
+        from .service.service import Service
 
-    def before_stop(self):
-        """Called before the application stops.
+        service = self._system_app.get_component(SERVE_SERVICE_COMPONENT_NAME, Service)
+        if service:
 
-        Cleanup resources.
-        """
-        logger.info("Stopping channel serve component")
+            async def startup_channels():
+                """Start all enabled channels on app startup."""
+                logger.info("Starting channel connection manager and enabled channels")
+                await service.start_connection_manager()
+                await service.start_all_channels()
+
+            async def shutdown_channels():
+                """Stop all channels on app shutdown."""
+                logger.info("Stopping all channels and connection manager")
+                await service.stop_all_channels()
+                await service.stop_connection_manager()
+
+            # Register the async handlers with FastAPI's event system
+            app = self._system_app.app
+            register_event_handler(app, "startup", startup_channels)
+            register_event_handler(app, "shutdown", shutdown_channels)

--- a/packages/derisk-serve/src/derisk_serve/channel/service/service.py
+++ b/packages/derisk-serve/src/derisk_serve/channel/service/service.py
@@ -2,17 +2,21 @@
 
 This module provides the main service for channel management.
 """
-
+import base64
+import hashlib
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
+from derisk.channel import ChannelConfig, ChannelType
+from derisk.channel.schemas import DingTalkConfig, FeishuConfig
 from derisk.component import SystemApp
 from derisk.storage.metadata._base_dao import REQ, RES
 from derisk_serve.core import BaseService
 
 from ..api.schemas import ChannelRequest, ChannelResponse, ChannelTestResponse
 from ..config import SERVE_SERVICE_COMPONENT_NAME, ServeConfig
+from ..connection import ChannelConnectionManager
 from ..models.models import ChannelDao, ChannelEntity
 
 logger = logging.getLogger(__name__)
@@ -42,6 +46,7 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
         """
         self._config = config
         self._dao = dao
+        self._connection_manager: Optional[ChannelConnectionManager] = None
         super().__init__(system_app)
 
     def init_app(self, system_app: SystemApp) -> None:
@@ -52,6 +57,86 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
         """
         super().init_app(system_app)
         self._dao = self._dao or ChannelDao(self._config)
+        self._connection_manager = ChannelConnectionManager()
+
+        # 设置默认消息处理器，带Agent集成
+        from derisk.channel.router import AgentMessageHandler
+
+        default_handler = AgentMessageHandler(
+            agent_app_code="main-orchestrator",
+            get_agent_response=self._get_agent_response_with_channel_context,
+        )
+        self._connection_manager.set_default_message_handler(default_handler)
+        logger.info("Default message handler initialized with agent integration")
+
+    async def _get_agent_response_with_channel_context(
+        self,
+        message,
+        history,
+        agent_app_code,
+        channel_context=None,
+    ):
+        """Get agent response with channel context for cron message delivery.
+
+        Args:
+            message: The incoming channel message.
+            history: Conversation history.
+            agent_app_code: The agent app code.
+            channel_context: Channel context including channel_id, receiver_id, etc.
+
+        Returns:
+            The agent's response content.
+        """
+        import uuid
+        from derisk_serve.agent.agents.controller import multi_agents
+
+        # Generate a conversation session ID based on the channel message
+        channel_conv_id = message.conversation_id or message.sender.user_id
+        conv_session_id = f"channel_{hashlib.md5(channel_conv_id.encode()).hexdigest()}"
+
+        try:
+            # Build ext_info with channel context for cron message delivery
+            ext_info = {}
+            if channel_context:
+                ext_info["channel"] = channel_context
+
+            # Create a callback to ensure final_report is populated
+            # This is needed for channel message delivery to work correctly
+            async def channel_callback(
+                conv_session_id: str,
+                agent_conv_id: str,
+                final_message: str,
+                final_report: str,
+                err_msg: Optional[str],
+                first_chunk_ms: Optional[int],
+                post_action_reports: Optional[list] = None,
+            ):
+                """Callback to enable final_report population for channel delivery.
+
+                The final_report is only populated when chat_call_back is callable,
+                so we need to provide this callback even if we don't need to do
+                anything special with the results.
+                """
+                if err_msg:
+                    logger.error(f"Channel agent execution error: {err_msg}")
+                else:
+                    logger.info(f"Channel agent execution completed for session {conv_session_id}")
+
+            # Call the agent chat with callback
+            result, agent_conv_id = await multi_agents.app_chat_v3(
+                conv_uid=conv_session_id,
+                gpts_name=agent_app_code,
+                user_query=message.content,
+                stream=False,  # Non-streaming for channel messages
+                background_tasks=None,
+                chat_call_back=channel_callback,  # Add callback for final_report
+                **ext_info,
+            )
+
+            return result or "处理完成"
+        except Exception as e:
+            logger.error(f"Error getting agent response: {e}")
+            raise
 
     @property
     def dao(self) -> ChannelDao:
@@ -62,6 +147,11 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
     def config(self) -> ServeConfig:
         """Returns the internal ServeConfig."""
         return self._config
+
+    @property
+    def connection_manager(self) -> Optional[ChannelConnectionManager]:
+        """Returns the connection manager."""
+        return self._connection_manager
 
     def create(self, request: REQ) -> RES:
         """Create a new entity."""
@@ -174,9 +264,6 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
     async def test_connection(self, channel_id: str) -> ChannelTestResponse:
         """Test the connection to a channel.
 
-        This is a placeholder that returns success. The actual implementation
-        should be provided by the channel handler in derisk-ext.
-
         Args:
             channel_id: The channel ID to test.
 
@@ -190,15 +277,54 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
                 message=f"Channel not found: {channel_id}",
             )
 
-        # Placeholder: actual implementation should be in derisk-ext
-        # The channel handler should be invoked here to test the connection
-        logger.info(f"Testing connection for channel {channel_id}")
+        try:
+            channel_type = ChannelType(channel.channel_type)
+        except ValueError:
+            return ChannelTestResponse(
+                success=False,
+                message=f"Invalid channel type: {channel.channel_type}",
+            )
 
-        return ChannelTestResponse(
-            success=True,
-            message="Connection test successful (placeholder)",
-            details={"channel_type": channel.channel_type},
+        config = ChannelConfig(
+            name=channel.name,
+            enabled=channel.enabled,
+            platform_config=channel.config,
         )
+
+        handler = self._connection_manager._registry.create_handler(
+            channel_id, channel_type, config
+        )
+
+        if not handler:
+            return ChannelTestResponse(
+                success=False,
+                message=f"Failed to create handler for channel type: {channel.channel_type}",
+            )
+
+        try:
+            success = await handler.test_connection(channel_id)
+            self._connection_manager._registry.remove_handler(channel_id)
+
+            if success:
+                return ChannelTestResponse(
+                    success=True,
+                    message="Connection test successful",
+                    details={"channel_type": channel.channel_type},
+                )
+            else:
+                return ChannelTestResponse(
+                    success=False,
+                    message="Connection test failed",
+                    details={"channel_type": channel.channel_type},
+                )
+        except Exception as e:
+            logger.error(f"Error testing connection: {e}")
+            self._connection_manager._registry.remove_handler(channel_id)
+            return ChannelTestResponse(
+                success=False,
+                message=f"Connection test error: {str(e)}",
+                details={"channel_type": channel.channel_type},
+            )
 
     async def enable_channel(self, channel_id: str) -> ChannelResponse:
         """Enable a channel.
@@ -263,3 +389,137 @@ class Service(BaseService[ChannelEntity, ChannelRequest, ChannelResponse]):
             List of enabled channel entities.
         """
         return self.dao.get_enabled_channels()
+
+    async def start_channel(self, channel_id: str) -> bool:
+        """Start a channel by ID.
+
+        Args:
+            channel_id: The channel ID to start.
+
+        Returns:
+            True if started successfully, False otherwise.
+        """
+        channel = await self.get_channel(channel_id)
+        if not channel:
+            logger.error(f"Channel not found: {channel_id}")
+            return False
+
+        if not channel.enabled:
+            logger.warning(f"Channel {channel_id} is disabled")
+            return False
+
+        if not self._connection_manager:
+            logger.error("Connection manager not initialized")
+            return False
+
+        try:
+            channel_type = ChannelType(channel.channel_type)
+        except ValueError:
+            logger.error(f"Invalid channel type: {channel.channel_type}")
+            return False
+
+        config = ChannelConfig(
+            name=channel.name,
+            enabled=channel.enabled,
+            platform_config=channel.config,
+        )
+
+        success = await self._connection_manager.start_channel(
+            channel_id, channel_type, config
+        )
+
+        if success:
+            await self.update_channel_status(channel_id, "connected")
+        else:
+            await self.update_channel_status(channel_id, "error", "Failed to start")
+
+        return success
+
+    async def stop_channel(self, channel_id: str) -> bool:
+        """Stop a channel by ID.
+
+        Args:
+            channel_id: The channel ID to stop.
+
+        Returns:
+            True if stopped successfully, False otherwise.
+        """
+        if not self._connection_manager:
+            logger.error("Connection manager not initialized")
+            return False
+
+        success = await self._connection_manager.stop_channel(channel_id)
+
+        if success:
+            await self.update_channel_status(channel_id, "disconnected")
+
+        return success
+
+    async def start_all_channels(self) -> Dict[str, bool]:
+        """Start all enabled channels.
+
+        Returns:
+            Dictionary mapping channel IDs to success status.
+        """
+        if not self._connection_manager:
+            logger.error("Connection manager not initialized")
+            return {}
+
+        enabled_channels = self.get_enabled_channels()
+        channels_data = [
+            {
+                "id": ch.id,
+                "name": ch.name,
+                "channel_type": ch.channel_type,
+                "config": ch.config,
+                "enabled": bool(ch.enabled),
+            }
+            for ch in enabled_channels
+        ]
+
+        results = await self._connection_manager.start_all_channels(channels_data)
+
+        for channel_id, success in results.items():
+            if success:
+                await self.update_channel_status(channel_id, "connected")
+            else:
+                await self.update_channel_status(channel_id, "error", "Failed to start")
+
+        return results
+
+    async def stop_all_channels(self) -> Dict[str, bool]:
+        """Stop all running channels.
+
+        Returns:
+            Dictionary mapping channel IDs to success status.
+        """
+        if not self._connection_manager:
+            logger.error("Connection manager not initialized")
+            return {}
+
+        results = await self._connection_manager.stop_all_channels()
+
+        for channel_id in results:
+            await self.update_channel_status(channel_id, "disconnected")
+
+        return results
+
+    def get_running_channels(self) -> List[str]:
+        """Get list of running channel IDs.
+
+        Returns:
+            List of channel IDs that are currently running.
+        """
+        if not self._connection_manager:
+            return []
+        return self._connection_manager.get_running_channels()
+
+    async def start_connection_manager(self) -> None:
+        """Start the connection manager."""
+        if self._connection_manager:
+            await self._connection_manager.start()
+
+    async def stop_connection_manager(self) -> None:
+        """Stop the connection manager."""
+        if self._connection_manager:
+            await self._connection_manager.stop()

--- a/packages/derisk-serve/src/derisk_serve/cron/service/service.py
+++ b/packages/derisk-serve/src/derisk_serve/cron/service/service.py
@@ -624,14 +624,37 @@ class Service(BaseService[CronJobEntity, ServeRequest, ServerResponse], CronSche
                 # Generate a new conversation ID for isolated sessions
                 conv_uid = str(uuid.uuid4())
 
-            # Execute the agent chat
+            # Create a simple callback for logging only
+            # Message delivery is handled by the Agent layer (see agent_chat.py)
+            async def execution_callback(
+                conv_session_id: str,
+                agent_conv_id: str,
+                final_message: str,
+                final_report: str,
+                err_msg: Optional[str],
+                first_chunk_ms: Optional[int],
+                post_action_reports: Optional[list] = None,
+            ):
+                """Simple callback for logging execution results.
+
+                Message delivery to channels is handled by the Agent layer
+                through the _deliver_to_channel_if_configured method.
+                """
+                if err_msg:
+                    logger.error(f"Agent execution error for job {job.id}: {err_msg}")
+                else:
+                    logger.info(f"Agent execution completed for job {job.id}")
+
+            # Execute the agent chat with callback
             # Note: gpts_name is the agent_id, user_query is the message
+            # app_chat_v3 returns (None, agent_conv_id) immediately since it runs in background
             result, agent_conv_id = await multi_agents.app_chat_v3(
                 conv_uid=conv_uid,
                 gpts_name=payload.agent_id,
                 user_query=payload.message or "",
                 stream=False,  # Non-streaming for cron jobs
                 background_tasks=None,
+                chat_call_back=execution_callback,
             )
 
             # If using shared session and got a new session ID, update the job
@@ -648,12 +671,13 @@ class Service(BaseService[CronJobEntity, ServeRequest, ServerResponse], CronSche
                             session.commit()
                             logger.info(f"Updated conv_session_id for job {job.id} to {conv_session_id}")
 
-            logger.info(f"Agent turn completed for job {job.id}, conv_uid={conv_uid}")
+            logger.info(f"Agent turn initiated for job {job.id}, conv_uid={conv_uid}")
             return True
         except Exception as e:
             logger.error(f"Agent execution failed: {e}")
             raise
 
+    
     def _update_job_state(
         self,
         job_id: str,

--- a/packages/derisk-serve/src/derisk_serve/cron/tools/create_cron_job.py
+++ b/packages/derisk-serve/src/derisk_serve/cron/tools/create_cron_job.py
@@ -71,7 +71,7 @@ async def create_cron_job(
     at_time: Optional[str] = None,
     timezone: Optional[str] = None,
     enabled: bool = True,
-    session_mode: str = "isolated",
+    session_mode: str = "shared",
     conv_session_id: Optional[str] = None,
     description: Optional[str] = None,
 ) -> str:
@@ -87,7 +87,7 @@ async def create_cron_job(
         at_time: ISO datetime string for 'at' schedule.
         timezone: Timezone for the schedule (default: system timezone).
         enabled: Whether the job is enabled immediately.
-        session_mode: Session mode for agent execution ('isolated' or 'shared', default 'isolated').
+        session_mode: Session mode for agent execution ('isolated' or 'shared', default 'shared').
         conv_session_id: Conversation session ID for shared session mode.
         description: Optional description of the job.
 

--- a/tests/channel/test_channel_core.py
+++ b/tests/channel/test_channel_core.py
@@ -1,0 +1,293 @@
+"""Unit tests for channel module.
+
+This module contains unit tests for:
+- Channel base types
+- Channel handler registry
+- Channel message router
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from derisk.channel import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelConnectionState,
+    ChannelHandler,
+    ChannelHandlerRegistry,
+    ChannelMessage,
+    ChannelMessageRouter,
+    ChannelSender,
+    ChannelType,
+    SendMessageResult,
+)
+from derisk.channel.router import AgentMessageHandler
+
+
+class TestChannelTypes:
+    """Tests for channel types and enums."""
+
+    def test_channel_type_values(self):
+        """Test that channel types have correct values."""
+        assert ChannelType.DINGTALK == "dingtalk"
+        assert ChannelType.FEISHU == "feishu"
+        assert ChannelType.WECHAT == "wechat"
+        assert ChannelType.QQ == "qq"
+
+    def test_channel_connection_state_values(self):
+        """Test connection state values."""
+        assert ChannelConnectionState.DISCONNECTED == "disconnected"
+        assert ChannelConnectionState.CONNECTING == "connecting"
+        assert ChannelConnectionState.CONNECTED == "connected"
+        assert ChannelConnectionState.ERROR == "error"
+        assert ChannelConnectionState.RECONNECTING == "reconnecting"
+
+
+class TestChannelModels:
+    """Tests for channel models."""
+
+    def test_channel_sender(self):
+        """Test ChannelSender model."""
+        sender = ChannelSender(
+            user_id="user123",
+            name="John Doe",
+            avatar="https://example.com/avatar.png",
+        )
+        assert sender.user_id == "user123"
+        assert sender.name == "John Doe"
+        assert sender.avatar == "https://example.com/avatar.png"
+
+    def test_channel_message(self):
+        """Test ChannelMessage model."""
+        message = ChannelMessage(
+            channel_type=ChannelType.DINGTALK,
+            message_id="msg123",
+            sender=ChannelSender(user_id="user123"),
+            content="Hello World",
+        )
+        assert message.channel_type == ChannelType.DINGTALK
+        assert message.message_id == "msg123"
+        assert message.content == "Hello World"
+        assert message.content_type == "text"
+        assert message.is_group == False
+
+    def test_channel_capabilities(self):
+        """Test ChannelCapabilities model."""
+        caps = ChannelCapabilities(
+            chat_types=["private", "group"],
+            threads=True,
+            media=["text", "image"],
+        )
+        assert "private" in caps.chat_types
+        assert caps.threads == True
+        assert "text" in caps.media
+
+    def test_send_message_result(self):
+        """Test SendMessageResult model."""
+        result = SendMessageResult(
+            success=True,
+            message_id="msg456",
+        )
+        assert result.success == True
+        assert result.message_id == "msg456"
+        assert result.error is None
+
+
+class TestChannelHandlerRegistry:
+    """Tests for ChannelHandlerRegistry."""
+
+    def test_singleton_pattern(self):
+        """Test that registry is a singleton."""
+        registry1 = ChannelHandlerRegistry.get_instance()
+        registry2 = ChannelHandlerRegistry.get_instance()
+        assert registry1 is registry2
+
+    def test_register_handler_class(self):
+        """Test registering a handler class."""
+        registry = ChannelHandlerRegistry.get_instance()
+
+        class MockHandler(ChannelHandler):
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            async def send_message(
+                self, receiver_id, content, content_type="text", **kwargs
+            ):
+                return SendMessageResult(success=True)
+
+            def get_connection_url(self):
+                return None
+
+            async def process_message(self, channel_id, message):
+                return None
+
+            def validate_signature(self, channel_id, signature, timestamp, nonce, body):
+                return True
+
+            def get_capabilities(self):
+                return ChannelCapabilities()
+
+            async def test_connection(self, channel_id):
+                return True
+
+        registry.register_handler_class(ChannelType.FEISHU, MockHandler)
+        assert ChannelType.FEISHU in registry.get_registered_types()
+
+    def test_create_handler(self):
+        """Test creating a handler instance."""
+        registry = ChannelHandlerRegistry.get_instance()
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+
+        handler = registry.create_handler(
+            channel_id="test_channel",
+            channel_type=ChannelType.FEISHU,
+            config=config,
+        )
+
+        assert handler is not None
+        assert handler.channel_id == "test_channel"
+
+    def test_get_capabilities_with_handler_class(self):
+        """Test get_capabilities returns capabilities from handler class."""
+        registry = ChannelHandlerRegistry.get_instance()
+
+        class MockHandlerWithCapabilities(ChannelHandler):
+            @classmethod
+            def get_default_capabilities(cls):
+                return ChannelCapabilities(
+                    chat_types=["private"],
+                    threads=True,
+                    media=["text", "image"],
+                    reactions=True,
+                    edit=True,
+                    reply=True,
+                )
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            async def send_message(
+                self, receiver_id, content, content_type="text", **kwargs
+            ):
+                return SendMessageResult(success=True)
+
+            def get_connection_url(self):
+                return None
+
+            async def process_message(self, channel_id, message):
+                return None
+
+            def validate_signature(self, channel_id, signature, timestamp, nonce, body):
+                return True
+
+            def get_capabilities(self):
+                return self.get_default_capabilities()
+
+            async def test_connection(self, channel_id):
+                return True
+
+        registry.register_handler_class(ChannelType.WECHAT, MockHandlerWithCapabilities)
+
+        capabilities = registry.get_capabilities(ChannelType.WECHAT)
+        assert capabilities is not None
+        assert "private" in capabilities.chat_types
+        assert capabilities.threads is True
+        assert "text" in capabilities.media
+
+    def test_get_capabilities_unregistered_type(self):
+        """Test get_capabilities returns None for unregistered type."""
+        registry = ChannelHandlerRegistry.get_instance()
+
+        # QQ is not registered
+        capabilities = registry.get_capabilities(ChannelType.QQ)
+        assert capabilities is None
+
+
+class TestChannelMessageRouter:
+    """Tests for ChannelMessageRouter."""
+
+    @pytest.mark.asyncio
+    async def test_router_start_stop(self):
+        """Test starting and stopping the router."""
+        router = ChannelMessageRouter()
+        await router.start()
+        assert router.is_running == True
+        await router.stop()
+        assert router.is_running == False
+
+    @pytest.mark.asyncio
+    async def test_message_handler_registration(self):
+        """Test registering a message handler."""
+        router = ChannelMessageRouter()
+
+        handler = AgentMessageHandler(agent_app_code="test_agent")
+        router.register_handler("channel1", handler)
+
+        # Handler should be registered
+        assert "channel1" in router._handlers
+
+    @pytest.mark.asyncio
+    async def test_default_handler(self):
+        """Test setting default message handler."""
+        router = ChannelMessageRouter()
+
+        handler = AgentMessageHandler()
+        router.set_default_handler(handler)
+
+        assert router._default_handler is handler
+
+
+class TestAgentMessageHandler:
+    """Tests for AgentMessageHandler."""
+
+    @pytest.mark.asyncio
+    async def test_handle_message(self):
+        """Test handling a message."""
+        handler = AgentMessageHandler()
+
+        message = ChannelMessage(
+            channel_type=ChannelType.DINGTALK,
+            message_id="msg1",
+            sender=ChannelSender(user_id="user1"),
+            content="Hello",
+        )
+
+        mock_channel_handler = MagicMock()
+        mock_channel_handler.send_message = AsyncMock(
+            return_value=SendMessageResult(success=True)
+        )
+
+        response = await handler.handle_message(message, mock_channel_handler)
+        assert response is not None
+
+    def test_conversation_management(self):
+        """Test conversation history management."""
+        handler = AgentMessageHandler()
+
+        # Add some history
+        handler._conversation_histories["conv1"] = [
+            {"role": "user", "content": "Hello"},
+        ]
+
+        # Clear conversation
+        handler.clear_conversation("conv1")
+        assert "conv1" not in handler._conversation_histories
+
+        # Add again
+        handler._conversation_histories["conv2"] = []
+
+        # Clear all
+        handler.clear_all_conversations()
+        assert len(handler._conversation_histories) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/channel/test_dingtalk.py
+++ b/tests/channel/test_dingtalk.py
@@ -1,0 +1,444 @@
+"""Unit tests for DingTalk channel implementation.
+
+This module contains unit tests for:
+- DingTalk client
+- DingTalk sender
+- DingTalk handler
+"""
+
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from derisk.channel import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelMessage,
+    ChannelType,
+    SendMessageResult,
+)
+from derisk.channel.schemas import DingTalkConfig
+
+from derisk_ext.channels.dingtalk.models import (
+    DingTalkEventType,
+    DingTalkMessageContent,
+    DingTalkMessageType,
+)
+
+
+class TestDingTalkModels:
+    """Tests for DingTalk models."""
+
+    def test_message_content(self):
+        """Test DingTalkMessageContent model."""
+        content = DingTalkMessageContent(
+            content="Hello World",
+            title="Test Title",
+        )
+        assert content.content == "Hello World"
+        assert content.title == "Test Title"
+
+    def test_event_type_enum(self):
+        """Test DingTalkEventType enum."""
+        assert DingTalkEventType.CHATBOT_MESSAGE.value == "chatbot_message"
+
+    def test_message_type_enum(self):
+        """Test DingTalkMessageType enum."""
+        assert DingTalkMessageType.TEXT.value == "text"
+        assert DingTalkMessageType.MARKDOWN.value == "markdown"
+
+
+class TestDingTalkSender:
+    """Tests for DingTalkSender."""
+
+    @pytest.mark.asyncio
+    async def test_send_text(self):
+        """Test sending text message."""
+        from derisk_ext.channels.dingtalk.sender import DingTalkSender
+
+        mock_client = MagicMock()
+        mock_client.send_private_message = AsyncMock(
+            return_value=SendMessageResult(success=True, message_id="msg123")
+        )
+
+        sender = DingTalkSender(mock_client)
+        result = await sender.send_text(
+            user_id="user123",
+            text="Hello World",
+        )
+
+        assert result.success == True
+        mock_client.send_private_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_markdown(self):
+        """Test sending markdown message."""
+        from derisk_ext.channels.dingtalk.sender import DingTalkSender
+
+        mock_client = MagicMock()
+        mock_client.send_private_message = AsyncMock(
+            return_value=SendMessageResult(success=True)
+        )
+
+        sender = DingTalkSender(mock_client)
+        result = await sender.send_markdown(
+            user_id="user123",
+            title="Test Title",
+            markdown_content="# Hello\n\nWorld",
+        )
+
+        assert result.success == True
+        mock_client.send_private_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_action_card(self):
+        """Test sending action card message."""
+        from derisk_ext.channels.dingtalk.sender import DingTalkSender
+
+        mock_client = MagicMock()
+        mock_client.send_private_message = AsyncMock(
+            return_value=SendMessageResult(success=True)
+        )
+
+        sender = DingTalkSender(mock_client)
+        result = await sender.send_action_card(
+            user_id="user123",
+            title="Card Title",
+            text="Card content",
+            btns=[
+                {"title": "Button 1", "actionURL": "https://example.com/1"},
+                {"title": "Button 2", "actionURL": "https://example.com/2"},
+            ],
+        )
+
+        assert result.success == True
+        mock_client.send_private_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_group_message(self):
+        """Test sending group message."""
+        from derisk_ext.channels.dingtalk.sender import DingTalkSender
+
+        mock_client = MagicMock()
+        mock_client.send_group_message = AsyncMock(
+            return_value=SendMessageResult(success=True)
+        )
+
+        sender = DingTalkSender(mock_client)
+        result = await sender.send_text(
+            user_id="user123",
+            text="Hello Group",
+            is_group=True,
+            conversation_id="conv123",
+        )
+
+        assert result.success == True
+        mock_client.send_group_message.assert_called_once()
+
+
+class TestDingTalkChannelHandler:
+    """Tests for DingTalkChannelHandler."""
+
+    def test_handler_creation(self):
+        """Test creating handler."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+        )
+
+        assert handler.channel_id == "test_channel"
+        assert handler._platform_config is not None
+
+    def test_get_capabilities(self):
+        """Test getting capabilities."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+        )
+
+        capabilities = handler.get_capabilities()
+        assert capabilities.threads == False
+        assert capabilities.reply == True
+        assert "text" in capabilities.media
+
+    def test_get_connection_url(self):
+        """Test getting connection URL (should be None for Stream mode)."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+        )
+
+        assert handler.get_connection_url() is None
+
+    def test_parse_chatbot_message_event(self):
+        """Test parsing chatbot_message event."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+        )
+
+        # ChatbotMessage format from DingTalkChatbotHandler
+        event_dict = {
+            "event_type": "chatbot_message",
+            "message_id": "msg123",
+            "conversation_id": "conv123",
+            "conversation_type": "private",
+            "conversation_title": None,
+            "sender_id": "user_union_id",
+            "sender_nick": "Test User",
+            "sender_staff_id": "staff123",
+            "sender_corp_id": "corp123",
+            "robot_code": "robot123",
+            "message_type": "text",
+            "text": "Hello World",
+            "at_users": [],
+            "session_webhook": "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+            "create_at": 1234567890000,
+            "is_in_at_list": False,
+        }
+
+        channel_message = handler._parse_chatbot_message_event(event_dict)
+
+        assert channel_message is not None
+        assert channel_message.channel_type == ChannelType.DINGTALK
+        assert channel_message.message_id == "msg123"
+        assert channel_message.conversation_id == "conv123"
+        assert channel_message.content == "Hello World"
+        assert channel_message.is_group == False
+        assert channel_message.sender.user_id == "staff123"
+        assert channel_message.sender.name == "Test User"
+
+    def test_parse_chatbot_message_event_group(self):
+        """Test parsing chatbot_message event for group chat."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+        )
+
+        # Group chat with @mention
+        event_dict = {
+            "event_type": "chatbot_message",
+            "message_id": "msg456",
+            "conversation_id": "conv456",
+            "conversation_type": "group",
+            "conversation_title": "Test Group",
+            "sender_id": "user_union_id",
+            "sender_nick": "Group User",
+            "sender_staff_id": "staff456",
+            "sender_corp_id": "corp123",
+            "robot_code": "robot123",
+            "message_type": "text",
+            "text": " @机器人 你好",
+            "at_users": [
+                {"dingtalkId": "atuser1", "staffId": "staff1"}
+            ],
+            "session_webhook": "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+            "create_at": 1234567890000,
+            "is_in_at_list": True,
+        }
+
+        channel_message = handler._parse_chatbot_message_event(event_dict)
+
+        assert channel_message is not None
+        assert channel_message.is_group == True
+        assert channel_message.mentions is not None
+        assert "atuser1" in channel_message.mentions
+        assert channel_message.extra.get("is_in_at_list") == True
+
+    def test_on_message_received(self):
+        """Test _on_message_received with chatbot_message event."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        received_messages = []
+
+        def message_callback(msg):
+            received_messages.append(msg)
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+            message_callback=message_callback,
+        )
+
+        event_dict = {
+            "event_type": "chatbot_message",
+            "message_id": "msg123",
+            "conversation_id": "conv123",
+            "conversation_type": "private",
+            "sender_id": "user123",
+            "sender_nick": "Test User",
+            "sender_staff_id": "staff123",
+            "text": "Test message",
+            "create_at": 1234567890000,
+        }
+
+        handler._on_message_received(event_dict)
+
+        assert len(received_messages) == 1
+        assert received_messages[0].content == "Test message"
+
+    def test_on_message_received_unknown_event(self):
+        """Test _on_message_received with unknown event type."""
+        from derisk_ext.channels.dingtalk.handler import DingTalkChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        received_messages = []
+
+        def message_callback(msg):
+            received_messages.append(msg)
+
+        handler = DingTalkChannelHandler(
+            channel_id="test_channel",
+            config=config,
+            platform_config=platform_config,
+            message_callback=message_callback,
+        )
+
+        # Unknown event type should not trigger callback
+        event_dict = {
+            "event_type": "unknown_event",
+            "data": {"foo": "bar"},
+        }
+
+        handler._on_message_received(event_dict)
+
+        assert len(received_messages) == 0
+
+
+class TestDingTalkClient:
+    """Tests for DingTalkClient."""
+
+    @pytest.mark.asyncio
+    async def test_get_access_token(self):
+        """Test getting access token."""
+        from derisk_ext.channels.dingtalk.client import DingTalkClient
+
+        config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        client = DingTalkClient(config)
+
+        with patch.object(
+            client._http_client, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "errcode": 0,
+                "access_token": "test_token",
+                "expires_in": 7200,
+            }
+            mock_get.return_value = mock_response
+
+            token = await client._get_access_token()
+
+            assert token == "test_token"
+            mock_get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_private_message(self):
+        """Test sending private message."""
+        from derisk_ext.channels.dingtalk.client import DingTalkClient
+
+        config = DingTalkConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        client = DingTalkClient(config)
+
+        with patch.object(
+            client._http_client, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_token_response = MagicMock()
+            mock_token_response.json.return_value = {
+                "errcode": 0,
+                "access_token": "test_token",
+                "expires_in": 7200,
+            }
+            mock_get.return_value = mock_token_response
+
+            with patch.object(
+                client._http_client, "post", new_callable=AsyncMock
+            ) as mock_post:
+                mock_response = MagicMock()
+                mock_response.json.return_value = {
+                    "processQueryKeys": ["key123"],
+                }
+                mock_post.return_value = mock_response
+
+                msg = {
+                    "msgKey": "sampleText",
+                    "msgParam": json.dumps({"content": "Hello"}),
+                }
+
+                result = await client.send_private_message(
+                    user_id="user123",
+                    msg=msg,
+                )
+
+                assert result.success == True
+                mock_post.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/channel/test_feishu.py
+++ b/tests/channel/test_feishu.py
@@ -1,0 +1,255 @@
+"""Unit tests for Feishu channel implementation.
+
+This module contains unit tests for:
+- Feishu client
+- Feishu sender
+- Feishu handler
+"""
+
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from derisk.channel import (
+    ChannelCapabilities,
+    ChannelConfig,
+    ChannelMessage,
+    ChannelType,
+    SendMessageResult,
+)
+from derisk.channel.schemas import FeishuConfig
+
+from derisk_ext.channels.feishu.models import (
+    FeishuEvent,
+    FeishuEventHeader,
+    FeishuMessage,
+    FeishuMessageContentType,
+    FeishuMessageEvent,
+    FeishuSender,
+)
+
+
+class TestFeishuModels:
+    """Tests for Feishu models."""
+
+    def test_feishu_sender(self):
+        """Test FeishuSender model."""
+        sender = FeishuSender(
+            sender_id={"open_id": "ou_xxx"},
+            sender_type="user",
+        )
+        assert sender.sender_id["open_id"] == "ou_xxx"
+        assert sender.sender_type == "user"
+
+    def test_feishu_message(self):
+        """Test FeishuMessage model."""
+        message = FeishuMessage(
+            message_id="om_xxx",
+            chat_id="oc_xxx",
+            message_type="text",
+            content='{"text": "Hello"}',
+            create_time="1234567890000",
+        )
+        assert message.message_id == "om_xxx"
+        assert message.chat_id == "oc_xxx"
+        assert message.message_type == "text"
+
+    def test_feishu_message_event(self):
+        """Test FeishuMessageEvent model."""
+        event = FeishuMessageEvent(
+            sender=FeishuSender(sender_id={"open_id": "ou_xxx"}),
+            message=FeishuMessage(
+                message_id="om_xxx",
+                chat_id="oc_xxx",
+                message_type="text",
+                content='{"text": "Hello"}',
+                create_time="1234567890000",
+            ),
+        )
+        assert event.sender.sender_id["open_id"] == "ou_xxx"
+        assert event.message.message_id == "om_xxx"
+
+    def test_feishu_event(self):
+        """Test FeishuEvent model."""
+        event = FeishuEvent(
+            header=FeishuEventHeader(
+                event_id="ev_xxx",
+                event_type="im.message.receive_v1",
+                create_time="1234567890",
+            ),
+            event={
+                "sender": {"sender_id": {"open_id": "ou_xxx"}},
+                "message": {
+                    "message_id": "om_xxx",
+                    "chat_id": "oc_xxx",
+                    "message_type": "text",
+                    "content": '{"text": "Hello"}',
+                    "create_time": "1234567890000",
+                },
+            },
+        )
+        assert event.header.event_id == "ev_xxx"
+        message_event = event.get_message_event()
+        assert message_event is not None
+        assert message_event.message.message_id == "om_xxx"
+
+
+class TestFeishuSender:
+    """Tests for FeishuSender."""
+
+    @pytest.mark.asyncio
+    async def test_send_text(self):
+        """Test sending text message."""
+        from derisk_ext.channels.feishu.sender import FeishuSender
+
+        mock_client = MagicMock()
+        mock_client.send_text_message = AsyncMock(
+            return_value=SendMessageResult(success=True, message_id="om_xxx")
+        )
+
+        sender = FeishuSender(mock_client)
+        result = await sender.send_text(
+            receive_id="oc_xxx",
+            text="Hello World",
+        )
+
+        assert result.success == True
+        mock_client.send_text_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_markdown(self):
+        """Test sending markdown message."""
+        from derisk_ext.channels.feishu.sender import FeishuSender
+
+        mock_client = MagicMock()
+        mock_client.send_message = AsyncMock(
+            return_value=SendMessageResult(success=True)
+        )
+
+        sender = FeishuSender(mock_client)
+        result = await sender.send_markdown(
+            receive_id="oc_xxx",
+            title="Test Title",
+            markdown_content="# Hello\n\nWorld",
+        )
+
+        assert result.success == True
+        mock_client.send_message.assert_called_once()
+
+        call_args = mock_client.send_message.call_args
+        assert call_args.kwargs["msg_type"] == "post"
+
+
+class TestFeishuChannelHandler:
+    """Tests for FeishuChannelHandler."""
+
+    def test_handler_initialization(self):
+        """Test handler initialization."""
+        from derisk_ext.channels.feishu.handler import FeishuChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = FeishuConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        try:
+            handler = FeishuChannelHandler(
+                channel_id="test_channel",
+                config=config,
+                platform_config=platform_config,
+            )
+            assert handler.channel_id == "test_channel"
+            assert handler._platform_config is not None
+        except ImportError:
+            pytest.skip("lark-oapi SDK not installed")
+
+    def test_get_capabilities(self):
+        """Test getting capabilities."""
+        from derisk_ext.channels.feishu.handler import FeishuChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = FeishuConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        try:
+            handler = FeishuChannelHandler(
+                channel_id="test_channel",
+                config=config,
+                platform_config=platform_config,
+            )
+
+            capabilities = handler.get_capabilities()
+            assert capabilities.threads == True
+            assert capabilities.reply == True
+            assert "text" in capabilities.media
+        except ImportError:
+            pytest.skip("lark-oapi SDK not installed")
+
+    def test_get_connection_url(self):
+        """Test getting connection URL (should be None for WebSocket mode)."""
+        from derisk_ext.channels.feishu.handler import FeishuChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = FeishuConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        try:
+            handler = FeishuChannelHandler(
+                channel_id="test_channel",
+                config=config,
+                platform_config=platform_config,
+            )
+            assert handler.get_connection_url() is None
+        except ImportError:
+            pytest.skip("lark-oapi SDK not installed")
+
+    def test_parse_message_event(self):
+        """Test parsing message event."""
+        from derisk_ext.channels.feishu.handler import FeishuChannelHandler
+
+        config = ChannelConfig(name="Test Channel", enabled=True)
+        platform_config = FeishuConfig(
+            app_id="test_app_id",
+            app_secret="test_secret",
+        )
+
+        try:
+            handler = FeishuChannelHandler(
+                channel_id="test_channel",
+                config=config,
+                platform_config=platform_config,
+            )
+
+            message_event = FeishuMessageEvent(
+                sender=FeishuSender(
+                    sender_id={"open_id": "ou_user123"},
+                    sender_type="user",
+                ),
+                message=FeishuMessage(
+                    message_id="om_msg123",
+                    chat_id="oc_chat123",
+                    message_type="text",
+                    content='{"text": "Hello World"}',
+                    create_time="1234567890000",
+                ),
+            )
+
+            channel_message = handler._parse_message_event(message_event)
+
+            assert channel_message is not None
+            assert channel_message.channel_type == ChannelType.FEISHU
+            assert channel_message.message_id == "om_msg123"
+            assert channel_message.conversation_id == "oc_chat123"
+            assert "Hello World" in channel_message.content
+        except ImportError:
+            pytest.skip("lark-oapi SDK not installed")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/web/src/app/channel/[id]/page.tsx
+++ b/web/src/app/channel/[id]/page.tsx
@@ -1,9 +1,0 @@
-import EditChannelClient from './edit-channel-client';
-
-export function generateStaticParams() {
-  return [{ id: 'placeholder' }];
-}
-
-export default function EditChannelPage() {
-  return <EditChannelClient />;
-}

--- a/web/src/app/channel/edit/page.tsx
+++ b/web/src/app/channel/edit/page.tsx
@@ -13,7 +13,7 @@ import {
 import { useRequest } from 'ahooks';
 import { App, Button, Card, Descriptions, Form, Popconfirm, Space, Switch, Tag, Typography } from 'antd';
 import moment from 'moment';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -22,8 +22,8 @@ const { Title, Text } = Typography;
 export default function EditChannelClient() {
   const { t } = useTranslation();
   const router = useRouter();
-  const params = useParams();
-  const channelId = params?.id as string;
+  const searchParams = useSearchParams();
+  const channelId = searchParams?.get('id') as string;
   const { message, modal } = App.useApp();
   const [form] = Form.useForm();
 
@@ -37,7 +37,7 @@ export default function EditChannelClient() {
       if (err) {
         throw err;
       }
-      return res?.data;
+      return res;
     },
     {
       ready: !!channelId,
@@ -61,7 +61,7 @@ export default function EditChannelClient() {
       if (err) {
         throw err;
       }
-      return res?.data;
+      return res;
     },
     {
       manual: true,
@@ -81,7 +81,7 @@ export default function EditChannelClient() {
       if (err) {
         throw err;
       }
-      return res?.data;
+      return res;
     },
     {
       manual: true,

--- a/web/src/app/channel/page.tsx
+++ b/web/src/app/channel/page.tsx
@@ -43,6 +43,8 @@ export default function ChannelPage() {
   const router = useRouter();
   const { message } = App.useApp();
   const [includeDisabled, setIncludeDisabled] = useState(false);
+  const [testingChannelId, setTestingChannelId] = useState<string | null>(null);
+  const [deletingChannelId, setDeletingChannelId] = useState<string | null>(null);
 
   // Fetch channels
   const {
@@ -55,7 +57,7 @@ export default function ChannelPage() {
       if (err) {
         return [];
       }
-      return res?.data || [];
+      return res || [];
     },
     {
       refreshDeps: [includeDisabled],
@@ -63,8 +65,9 @@ export default function ChannelPage() {
   );
 
   // Delete channel
-  const { run: runDeleteChannel, loading: deleteLoading } = useRequest(
+  const { run: runDeleteChannel } = useRequest(
     async (channelId: string) => {
+      setDeletingChannelId(channelId);
       const [err] = await apiInterceptors(deleteChannel(channelId));
       if (err) {
         throw err;
@@ -72,6 +75,9 @@ export default function ChannelPage() {
     },
     {
       manual: true,
+      onFinally: () => {
+        setDeletingChannelId(null);
+      },
       onSuccess: () => {
         message.success(t('channel_delete_success'));
         refreshChannels();
@@ -83,16 +89,20 @@ export default function ChannelPage() {
   );
 
   // Test connection
-  const { run: runTestChannel, loading: testLoading } = useRequest(
+  const { run: runTestChannel } = useRequest(
     async (channelId: string) => {
+      setTestingChannelId(channelId);
       const [err, res] = await apiInterceptors(testChannel(channelId));
       if (err) {
         throw err;
       }
-      return res?.data;
+      return res;
     },
     {
       manual: true,
+      onFinally: () => {
+        setTestingChannelId(null);
+      },
       onSuccess: (data) => {
         if (data?.success) {
           message.success(t('channel_test_success'));
@@ -113,7 +123,7 @@ export default function ChannelPage() {
       dataIndex: 'name',
       key: 'name',
       render: (name: string, record: ChannelResponse) => (
-        <Link href={`/channel/${record.id}`} className="text-blue-500 hover:text-blue-700 flex items-center gap-2">
+        <Link href={`/channel/edit?id=${record.id}`} className="text-blue-500 hover:text-blue-700 flex items-center gap-2">
           {channelTypeIcons[record.channel_type]}
           {name}
         </Link>
@@ -180,14 +190,14 @@ export default function ChannelPage() {
             <Button
               type="text"
               icon={<EditOutlined />}
-              onClick={() => router.push(`/channel/${record.id}`)}
+              onClick={() => router.push(`/channel/edit?id=${record.id}`)}
             />
           </Tooltip>
           <Tooltip title={t('channel_test')}>
             <Button
               type="text"
               icon={<ApiOutlined />}
-              loading={testLoading}
+              loading={testingChannelId === record.id}
               onClick={() => runTestChannel(record.id)}
             />
           </Tooltip>
@@ -198,7 +208,7 @@ export default function ChannelPage() {
             cancelText={t('No')}
           >
             <Tooltip title={t('Delete')}>
-              <Button type="text" danger icon={<DeleteOutlined />} loading={deleteLoading} />
+              <Button type="text" danger icon={<DeleteOutlined />} loading={deletingChannelId === record.id} />
             </Tooltip>
           </Popconfirm>
         </Space>


### PR DESCRIPTION
## Summary
- Implement ChannelHandlerRegistry for managing channel handlers (singleton pattern)
- Add ChannelMessageRouter and AgentMessageHandler for message routing to agents
- Add DingTalk and Feishu channel handlers with Stream mode support
- Implement message delivery from Agent layer via `_deliver_to_channel_if_configured`
- Add `chat_call_back` to ensure `final_report` is populated for channel delivery
- Decouple Cron service from Channel message delivery logic
- Store channel context in conversation `extra` field for delivery routing
- Add ChannelConnectionManager for channel lifecycle management
- Update web UI for channel management

## Architecture

### Before (Coupled)
```
Cron Service
├── Task scheduling
├── Agent invocation
└── Message delivery ← Too many responsibilities
    └── Channel Handler
```

### After (Decoupled)
```
Cron Service
├── Task scheduling
└── Agent invocation

Agent Layer
├── Conversation management
├── Execution callback
└── Message delivery ← Handled here
    └── Channel Handler
```

## Test plan
- [ ] Configure DingTalk Channel and verify connection
- [ ] Send message via DingTalk to create cron job (e.g., "每小时提醒我一次当前时间")
- [ ] Verify `gpts_conversations.extra` contains channel info
- [ ] Verify cron job created with `conv_session_id`
- [ ] Wait for trigger and verify DingTalk receives message

🤖 Generated with [Claude Code](https://claude.com/claude-code)