### PR TITLE
fix: handle non-JSON-serializable objects in MCP tool calls

### DIFF
--- a/packages/derisk-serve/src/derisk_serve/agent/resource/tool/mcp_utils.py
+++ b/packages/derisk-serve/src/derisk_serve/agent/resource/tool/mcp_utils.py
@@ -22,6 +22,45 @@ from derisk_serve.agent.db.gpts_tool_messages import (
     GptsToolMessages,
 )
 
+
+def _make_json_serializable(obj: Any) -> Any:
+    """将对象转换为 JSON 可序列化的格式。
+
+    处理包括 AgentFileSystem 等非序列化对象，将其转换为字符串或字典表示。
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, (list, tuple)):
+        return [_make_json_serializable(item) for item in obj]
+    if isinstance(obj, dict):
+        return {k: _make_json_serializable(v) for k, v in obj.items()}
+
+    # 处理 AgentFileSystem 和其他常见非序列化类型
+    type_name = type(obj).__name__
+
+    # AgentFileSystem 类型 - 转换为字符串表示
+    if type_name == "AgentFileSystem":
+        return f"<AgentFileSystem: {getattr(obj, 'root_path', str(obj))}>"
+
+    # Pydantic 模型 - 使用 model_dump 或 dict
+    if hasattr(obj, "model_dump"):
+        return _make_json_serializable(obj.model_dump())
+    if hasattr(obj, "dict"):
+        return _make_json_serializable(obj.dict())
+
+    # dataclass - 使用 asdict
+    if hasattr(obj, "__dataclass_fields__"):
+        from dataclasses import asdict
+        return _make_json_serializable(asdict(obj))
+
+    # 其他对象 - 尝试转换为字符串
+    try:
+        return str(obj)
+    except Exception:
+        return f"<{type_name}: unserializable>"
+
 logger = logging.getLogger(__name__)
 tool_cache = TTLCache(maxsize=200, ttl=300)
 gpts_tool_messages_dao = GptsToolMessagesDao()
@@ -184,12 +223,15 @@ async def call_mcp_tool(
         tool_id = str(uuid.uuid4())
 
     async def call_tool(server: str, arguments: dict):
+        # 将参数转换为 JSON 可序列化格式，处理 AgentFileSystem 等对象
+        serializable_arguments = _make_json_serializable(arguments)
+
         gpts_tool_messages = GptsToolMessages(
             tool_id=tool_id,
             name=mcp_name,
             sub_name=tool_name,
             type="MCP",
-            input=json.dumps(arguments, ensure_ascii=False),
+            input=json.dumps(serializable_arguments, ensure_ascii=False),
             success=1,
             trace_id=trace_id,
         )
@@ -213,7 +255,7 @@ async def call_mcp_tool(
             ) as (read, write):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
-                    result = await session.call_tool(tool_name, arguments=arguments)
+                    result = await session.call_tool(tool_name, arguments=serializable_arguments)
                     end_time = int(datetime.now().timestamp() * 1000)
                     LOGGER.info(
                         f"[DIGEST][tools/call]mcp_server=[{mcp_name}],sse=[{mcp_server}],success=[Y],err_msg=[],tool=[{tool_name}],costMs=[{end_time - start_time}],result_length=[{len(str(result.json()))}],headers=[{headers}],result:[{result.json()}]"


### PR DESCRIPTION
Add `_make_json_serializable()` helper to convert AgentFileSystem and other non-serializable objects to strings before passing to MCP SDK. This fixes PydanticSerializationError when AgentFileSystem is inadvertently included in tool arguments.

Changes:
- Add recursive serialization helper supporting Pydantic models, dataclasses, and custom objects like AgentFileSystem
- Apply conversion before both logging (GptsToolMessages.input) and actual MCP session.call_tool() invocation

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
