### PR TITLE
fix(db): extend gpts_app_config.custom_variables from VARCHAR(2000) t…

### DIFF
--- a/assets/schema/derisk.sql
+++ b/assets/schema/derisk.sql
@@ -9,7 +9,7 @@ use derisk;
 -- MySQL DDL Script for Derisk
 -- Version: 0.3.0
 -- Generated from SQLAlchemy ORM Models
--- Generated: 2026-03-18 00:22:14
+-- Generated: 2026-03-21 15:56:36
 -- ============================================================
 
 SET NAMES utf8mb4;
@@ -478,7 +478,7 @@ CREATE TABLE IF NOT EXISTS `gpts_app_config` (
   `system_prompt_template` TEXT NULL COMMENT '当前版本配置的system prompt模版',
   `user_prompt_template` TEXT NULL COMMENT '当前版本配置的user prompt模版',
   `layout` VARCHAR(255) NULL COMMENT '当前版本配置的布局配置',
-  `custom_variables` VARCHAR(2000) NULL COMMENT '当前版本配置自定义参数配置',
+  `custom_variables` TEXT NULL COMMENT '当前版本配置自定义参数配置',
   `llm_config` TEXT NULL COMMENT '当前版本配置的模型配置',
   `resource_knowledge` TEXT NULL COMMENT '当前版本配置的知识配置',
   `resource_tool` TEXT NULL COMMENT '当前版本配置的工具配置',

--- a/assets/schema/upgrade_custom_variables_text.sql
+++ b/assets/schema/upgrade_custom_variables_text.sql
@@ -1,0 +1,6 @@
+-- Upgrade script: extend custom_variables column from VARCHAR(2000) to TEXT
+-- Issue: Data too long for column 'custom_variables' when saving agent configs
+-- Date: 2026-03-23
+
+-- For MySQL/MariaDB
+ALTER TABLE `gpts_app_config` MODIFY COLUMN `custom_variables` TEXT NULL COMMENT '当前版本配置自定义参数配置';

--- a/packages/derisk-serve/src/derisk_serve/building/config/models/models.py
+++ b/packages/derisk-serve/src/derisk_serve/building/config/models/models.py
@@ -81,7 +81,7 @@ class ServeEntity(Model):
 
     layout = Column(String(255), nullable=True, comment="当前版本配置的布局配置")
     custom_variables = Column(
-        String(2000), nullable=True, comment="当前版本配置自定义参数配置"
+        Text, nullable=True, comment="当前版本配置自定义参数配置"
     )
     llm_config = Column(Text, nullable=True, comment="当前版本配置的模型配置")
     resource_knowledge = Column(Text, nullable=True, comment="当前版本配置的知识配置")

--- a/scripts/mysql_ddl.sql
+++ b/scripts/mysql_ddl.sql
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS `gpts_app_config` (
   `system_prompt_template` TEXT NULL COMMENT '当前版本配置的system prompt模版',
   `user_prompt_template` TEXT NULL COMMENT '当前版本配置的user prompt模版',
   `layout` VARCHAR(255) NULL COMMENT '当前版本配置的布局配置',
-  `custom_variables` VARCHAR(2000) NULL COMMENT '当前版本配置自定义参数配置',
+  `custom_variables` TEXT NULL COMMENT '当前版本配置自定义参数配置',
   `llm_config` VARCHAR(1000) NULL COMMENT '当前版本配置的模型配置',
   `resource_knowledge` VARCHAR(2000) NULL COMMENT '当前版本配置的知识配置',
   `resource_tool` VARCHAR(2000) NULL COMMENT '当前版本配置的工具配置',


### PR DESCRIPTION

Resolve MySQL DataError (1406) when saving agent configurations with large custom_variables JSON payloads (>2000 chars).

Changes:
- Schema (derisk.sql, mysql_ddl.sql): VARCHAR(2000) -> TEXT
- SQLAlchemy model: String(2000) -> Text
- Add upgrade script for existing databases

Fixes: Data too long for column 'custom_variables' at row 1

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
