### PR TITLE
fix: replace bare except with except Exception in utils

### DIFF
--- a/packages/derisk-core/src/derisk/agent/util/xml_utils.py
+++ b/packages/derisk-core/src/derisk/agent/util/xml_utils.py
@@ -17,7 +17,7 @@ def extract_valid_xmls(text) -> List[str]:
             # 尝试解析 XML
             xmltodict.parse(xml_str)
             valid_xmls.append(xml_str)
-        except:
+        except Exception:
             # 解析失败则跳过
             continue
     return valid_xmls

--- a/packages/derisk-core/src/derisk/util/date_utils.py
+++ b/packages/derisk-core/src/derisk/util/date_utils.py
@@ -62,10 +62,10 @@ def uniform_time(date_time: datetime | str | int | float) -> datetime:
     try:
         if isinstance(date_time, str):
             date_time = int(date_time)
-    except:
+    except Exception:
         try:
             date_time = float(date_time)
-        except:
+        except Exception:
             pass
 
     if isinstance(date_time, int):


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in `date_utils.py` (2 occurrences) and `xml_utils.py` (1 occurrence).

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intended. Using `except Exception:` follows PEP 8 best practices.

**Changes:**
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Files Changed
- `packages/derisk-core/src/derisk/util/date_utils.py` — 2 bare except → except Exception
- `packages/derisk-core/src/derisk/agent/util/xml_utils.py` — 1 bare except → except Exception

## Testing
No behavior change for normal exceptions — style/correctness fix only.