### PR TITLE
fix: remove merge conflict marker in runtime.py

### DIFF
--- a/packages/derisk-core/src/derisk/agent/core_v2/integration/runtime.py
+++ b/packages/derisk-core/src/derisk/agent/core_v2/integration/runtime.py
@@ -736,7 +736,6 @@ class V2AgentRuntime:
                     f"[_execute_stream] Injected interaction gateway into agent"
                 )
 
-<<<<<<< HEAD
             # 注入 GptsMemory（用于VIS推送）- backup in case _get_or_create_agent missed it
             if self.gpts_memory and hasattr(agent, "set_gpts_memory"):
                 if not getattr(agent, "_gpts_memory", None):


### PR DESCRIPTION
## Summary
- Removed `<<<<<<< HEAD` merge conflict marker from `runtime.py` that was causing SyntaxError on startup
- The file now starts correctly without syntax errors